### PR TITLE
[L] feat(schedule): /schedule 頁面實作（chip timeline + 對戰卡 + 三狀態）

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,14 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://waterfat.github.io',
   base: '/taan-basketball-league',
   trailingSlash: 'ignore',
+  integrations: [react()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/docs/delivery/issue-1_qaplan.md
+++ b/docs/delivery/issue-1_qaplan.md
@@ -1,0 +1,125 @@
+# Issue #1 QA Plan — /schedule 賽程頁
+
+**平台偵測**：Web 靜態站（Astro 6 + Tailwind 4 + TypeScript strict）
+**測試框架**：Vitest（unit + integration） + Playwright（E2E）
+**測試環境**：dev = http://localhost:4321/taan-basketball-league/、prod = https://waterfat.github.io/taan-basketball-league/
+
+---
+
+## 平台偵測結果
+
+- 框架：Astro 6（multi-page，純靜態）
+- E2E 工具：Playwright（projects: regression / regression-mobile / features）
+- Auth：無（公開讀取）
+- 資料源：Google Apps Script Webapp + 靜態 JSON fallback
+- Test fixtures: `tests/fixtures/schedule.ts`（已建立工廠函式）
+- Mock helper: `tests/helpers/mock-api.ts`（攔截 GAS / JSON 請求）
+
+## Tag 搜尋結果（既有 testcase）
+
+新專案首個 Issue，無既有 testcase 可復用。所有 testcase 為新建。
+
+---
+
+## Coverage Matrix
+
+| Coverage ID | B-ID | 行為 | 層 | 狀態 | 位置 |
+|---|---|---|---|---|---|
+| E-1 | B-1.1 | 預設顯示當前週的 Hero header | e2e | ❌→已補寫 | `tests/e2e/features/schedule.spec.ts:AC-1` |
+| E-2 | B-1.2 | Hero 顯示週次 + 階段 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-1` |
+| E-3 | B-1.3 | Hero 顯示日期 + 場地 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-1` |
+| E-4 | B-1.4 | chip timeline 渲染所有週 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-1` |
+| E-5 | B-1.5 | 當前週 chip 高亮 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-1` |
+| E-6 | B-1.6 | 渲染 6 張對戰卡 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-1` |
+| E-7 | B-2.1~3 | 點 chip 切週同步更新 Hero + cards | e2e | ❌→已補寫 | `schedule.spec.ts:AC-2` |
+| E-8 | B-3.1 | 完賽比分大字顯示 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-3` |
+| E-9 | B-3.2 | 贏家視覺強調 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-3` |
+| U-1 | B-3.3 | 平手場次處理 [qa-v2 補充] | unit | ⬜ Phase 2 | `tests/unit/winner-logic.test.ts` |
+| E-10 | B-4.1 | upcoming 比分顯示「— vs —」 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-4` |
+| E-11 | B-4.2 | upcoming 徽章「即將進行」 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-4` |
+| E-12 | B-5.1~2 | finished 卡片可點 → /boxscore | e2e | ❌→已補寫 | `schedule.spec.ts:AC-5` |
+| E-13 | B-5.3 | upcoming 卡片不可點 [qa-v2 補充] | e2e | ❌→已補寫 | `schedule.spec.ts:AC-5b [qa-v2]` |
+| E-14 | B-6.1~3 | 展開工作人員 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-6` |
+| E-15 | B-6.4 | 再次點擊收起 [qa-v2 補充] | e2e | ❌→已補寫 | `schedule.spec.ts:AC-6b [qa-v2]` |
+| U-2 | B-6.5 | 無 staff 資料時 toggle 顯示處理 [qa-v2 補充] | unit | ⬜ Phase 2 | `tests/unit/staff-display.test.ts` |
+| E-16 | B-7.1~2 | 「休」chip 點開顯示原因 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-7` |
+| E-17 | B-7.3 | 點「休」不切走 Hero header [qa-v2 補充] | e2e | ❌→已補寫 | `schedule.spec.ts:AC-7b [qa-v2]` |
+| E-18 | B-8.1 | mobile chip 顯示緊湊版「W5」 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-8 (regression-mobile)` |
+| E-19 | B-8.2 | mobile 卡片直排 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-8` |
+| E-20 | B-9.1 | desktop chip 顯示「W5 · 2/7」 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-9 (regression)` |
+| E-21 | B-9.2 | desktop 卡片並排兩欄 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-9` |
+| E-22 | B-10.1~2 | 載入中顯示 skeleton | e2e | ❌→已補寫 | `schedule.spec.ts:AC-10` |
+| E-23 | B-10.3 | 資料返回後 skeleton 消失 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-10` |
+| I-1 | B-11.1 | GAS 失敗 fallback JSON | integration | ❌→已補寫 | `tests/integration/api-fallback.integration.test.ts` |
+| I-2 | B-11.2 | GAS + JSON 全失敗 | integration | ❌→已補寫 | `api-fallback.integration.test.ts` |
+| E-24 | B-11.2~3 | 全失敗顯示「無法載入」+ 重試按鈕 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-11` |
+| E-25 | B-11.4 | 點重試重新載入 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-11b` |
+| E-26 | B-12.1~3 | 空狀態顯示 emoji + 訊息 + 看上一週按鈕 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-12` |
+| U-3 | B-12.4 | 找上一個有資料週的邏輯 | unit | ⬜ Phase 2 | `tests/unit/find-previous-week.test.ts` |
+| E-27 | B-13.1 | 第 1 週「看上一週」禁用/隱藏 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-13` |
+| E-28 | B-14.1 | 連續 3 週暫停 → 3 個獨立 chip | e2e | ❌→已補寫 | `schedule.spec.ts:AC-14` |
+| E-29 | B-14.2 | 每個「休」chip 都可獨立顯示原因 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-14` |
+| E-30 | B-15.1 | 同週 finished + upcoming 各自正確渲染 | e2e | ❌→已補寫 | `schedule.spec.ts:AC-15` |
+| U-4 | B-1.1 | getCurrentWeek 邏輯（從 currentWeek 找對應 week 物件） | unit | ⬜ Phase 2 | `tests/unit/schedule-utils.test.ts` |
+| U-5 | B-3.1 | isWinner / 比分判斷邏輯 | unit | ⬜ Phase 2 | `tests/unit/schedule-utils.test.ts` |
+| U-6 | B-7.1 | suspended week 偵測邏輯 | unit | ⬜ Phase 2 | `tests/unit/schedule-utils.test.ts` |
+
+說明：
+- E-* 已寫入 `tests/e2e/features/schedule.spec.ts`，total ~21 個 describe block，覆蓋 AC-1~15 + qa-v2 補充
+- I-* 已寫入 `tests/integration/api-fallback.integration.test.ts`，4 個 case 已驗證通過
+- U-* ⬜ 由 Phase 2 task 建立
+
+---
+
+## Phase 3 執行清單（Integration）
+
+- 新補：`tests/integration/api-fallback.integration.test.ts`
+  - GAS 成功 → source: gas
+  - GAS 失敗 → fallback JSON（source: static）
+  - 全失敗 → source: error
+  - GAS_URL 是 placeholder → 直接走 JSON
+
+→ 已驗證：`npm test` 4/4 通過
+
+## Phase 6 執行清單（E2E）
+
+**P0 regression 維持空**（首個 Issue，無 cross-issue 行為需要回歸）
+
+**Features：** `tests/e2e/features/schedule.spec.ts`
+- describe: `Schedule Page @schedule` — 17 個 case（AC-1~15 + qa-v2 補充）
+- describe: `Schedule Page RWD @schedule` — 2 個 case（mobile / desktop viewport）
+
+執行命令：
+```bash
+npx playwright test tests/e2e/features/schedule.spec.ts
+# 或：npm run test:e2e -- --project=features --project=regression-mobile
+```
+
+---
+
+## 測試資料策略（Issue 確認）
+
+- **正常情境（AC-1~9, AC-14~15）**：用 `tests/fixtures/schedule.ts` 工廠函式建立 `mockFullSchedule()` 等資料
+  - 包含已完賽週（W1, W5）+ 暫停週 × 3（過年連假）+ 即將進行週（W7）+ 混合週（W6）
+  - 結構符合 `public/data/schedule.json` 真實 schema
+- **空狀態 / 錯誤 / 延遲（AC-10~12, AC-13）**：手寫小量 mock + `mockScheduleAPI()` helper 模擬
+- **絕不打 production GAS**：所有 fetch 在 Playwright 測試啟動時被 `page.route()` 攔截
+
+---
+
+## 前置資源
+
+| 類型 | 狀態 | 路徑 |
+|---|---|---|
+| Auth helper | ❌ 不需要（無登入功能） | — |
+| Fixtures | ✅ 已建立 | `tests/fixtures/schedule.ts` |
+| Mock API helper | ✅ 已建立 | `tests/helpers/mock-api.ts` |
+| Visual helper | ⏸ 不在本 Issue 範圍 | — |
+
+---
+
+## 已知限制
+
+- E2E 中比分大字判斷靠 `data-testid` 與 `data-winner` attribute（待 Phase 2 實作）
+- chip 切換的 URL 同步行為（deep link 支援）目前未在 AC 內，未列入測試（如果有需要可加 query param 機制）
+- Visual screenshot regression（截圖比對）未啟用，UI 視覺對比靠人工 / Playwright 內建 snapshot

--- a/docs/specs/plans/issue-1_schedule-page.md
+++ b/docs/specs/plans/issue-1_schedule-page.md
@@ -1,0 +1,1047 @@
+# Issue #1 — /schedule 賽程頁實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 實作 /schedule 賽程頁，含 Hero header、chip timeline、對戰卡（含 staff 展開）、loading/error/empty 三狀態，三層 fallback（GAS → static JSON → empty）。
+
+**Architecture:** 單頁 Astro page（`src/pages/schedule.astro`）渲染靜態框架，內含一個 React island（`ScheduleApp`）負責所有互動邏輯與資料抓取。State 管理用 React hooks（useState + useEffect），不引入額外 store。資料層沿用 `src/lib/api.ts` 的三層 fallback。
+
+**Tech Stack:** Astro 6 / Tailwind 4 / React 19 island / TypeScript strict / Vitest / Playwright
+
+**個人風格規則**：命中 1 條 — `style-skeleton-loading`（AC-10 + 切週瞬間需有視覺回饋）
+
+**Code Graph**：圖未建立（新專案首個 Issue），跳過
+
+---
+
+## Coverage Matrix
+
+從 `docs/delivery/issue-1_qaplan.md` 載入。E-* 已寫入 `tests/e2e/features/schedule.spec.ts`，I-* 已寫入 `tests/integration/api-fallback.integration.test.ts`，皆通過。U-* ⬜ 由本計畫 Task 建立。
+
+| qaplan ID | 描述 | 對應 Task | 覆蓋方式 |
+|-----------|------|-----------|---------|
+| U-1 | 平手場次處理 | Task 2 Step 1 | unit (`schedule-utils.test.ts`) |
+| U-2 | 無 staff 資料時 toggle 顯示處理 | Task 5 Step 1 | unit (`staff-display.test.ts`) |
+| U-3 | 找上一個有資料週的邏輯 | Task 2 Step 1 | unit (`schedule-utils.test.ts`) |
+| U-4 | getCurrentWeek 邏輯 | Task 2 Step 1 | unit (`schedule-utils.test.ts`) |
+| U-5 | isWinner / 比分判斷 | Task 2 Step 1 | unit (`schedule-utils.test.ts`) |
+| U-6 | suspended week 偵測邏輯 | Task 2 Step 1 | unit (`schedule-utils.test.ts`) |
+| I-1, I-2 | api.ts 三層 fallback | — | `tests/integration/api-fallback.integration.test.ts`（已通過 Phase 1.2） |
+| E-1 ~ E-30 | 全部 E2E（含 RWD + 三狀態）| — | `tests/e2e/features/schedule.spec.ts`（Phase 6 執行） |
+
+---
+
+## 檔案規劃
+
+### 新建
+- `src/types/schedule.ts` — TypeScript 型別（Week / Game / ScheduleData）
+- `src/lib/schedule-utils.ts` — 純函式（getCurrentWeek、findPreviousWeekWithData、getWinner、isSuspended、hasStaff）
+- `src/components/schedule/SkeletonState.tsx` — 載入骨架
+- `src/components/schedule/ErrorState.tsx` — 錯誤訊息 + 重試
+- `src/components/schedule/EmptyState.tsx` — 「本週無賽程」+ 看上一週按鈕
+- `src/components/schedule/ScheduleHero.tsx` — Hero 標題區
+- `src/components/schedule/ChipTimeline.tsx` — 週次 chip 列（含 suspended chip + popover）
+- `src/components/schedule/GameCard.tsx` — 對戰卡（含 staff 展開）
+- `src/components/schedule/ScheduleApp.tsx` — 主 island，組裝以上所有元件 + 狀態管理
+- `tests/unit/schedule-utils.test.ts` — Task 2 TDD
+- `tests/unit/staff-display.test.ts` — Task 5 TDD
+
+### 修改
+- `src/pages/schedule.astro` — 移除 stub，掛載 `<ScheduleApp client:load />`
+- `astro.config.mjs` — 加 `@astrojs/react` integration
+- `package.json` — 加 react、react-dom、@astrojs/react、@types/react、@types/react-dom
+
+### 不修改（已存在通過）
+- `src/lib/api.ts`（三層 fallback 已實作 + 4 個 integration test 通過）
+- `tests/e2e/features/schedule.spec.ts`（qa-v2 已寫，本 plan 不重寫）
+- `tests/integration/api-fallback.integration.test.ts`（qa-v2 已寫並通過）
+
+---
+
+## Task 相依與並行
+
+```
+Task 1 (Astro React 整合)            ↓
+  ↓
+Task 2 (utils + types)
+  ↓
+  ├─ Task 3 (state components)  ⎫
+  ├─ Task 4 (ChipTimeline)      ⎬─ 並行
+  ├─ Task 5 (GameCard)          ⎪
+  └─ Task 6 (ScheduleHero)      ⎭
+  ↓
+Task 7 (ScheduleApp 主 island)
+  ↓
+Task 8 (頁面整合 + E2E 驗證)
+```
+
+並行群組：B = {3, 4, 5, 6}，可同時 dispatch 4 個 subagent。
+
+---
+
+## Task 1：加入 Astro React 整合
+
+**Files:**
+- Modify: `package.json`
+- Modify: `astro.config.mjs`
+
+- [ ] **Step 1：安裝套件**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-1
+npm install --save react@^19 react-dom@^19 @astrojs/react
+npm install --save-dev @types/react @types/react-dom
+```
+
+- [ ] **Step 2：修改 `astro.config.mjs` 加 react integration**
+
+```javascript
+// @ts-check
+import { defineConfig } from 'astro/config';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  site: 'https://waterfat.github.io',
+  base: '/taan-basketball-league',
+  trailingSlash: 'ignore',
+  integrations: [react()],
+  vite: { plugins: [tailwindcss()] },
+});
+```
+
+- [ ] **Step 3：驗證 build 通過**
+
+```bash
+npm run build
+```
+預期：build 成功，現有 5 個頁面照常產出。
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add package.json package-lock.json astro.config.mjs
+git commit -m "feat(deps): add @astrojs/react integration for schedule island (#1)"
+```
+
+---
+
+## Task 2：Schedule utils + types（TDD：U-1, U-3, U-4, U-5, U-6）
+
+**Files:**
+- Create: `src/types/schedule.ts`
+- Create: `src/lib/schedule-utils.ts`
+- Create: `tests/unit/schedule-utils.test.ts`
+
+- [ ] **Step 1：寫失敗測試**
+
+```typescript
+// tests/unit/schedule-utils.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  getCurrentWeek,
+  findPreviousWeekWithData,
+  getWinner,
+  isSuspended,
+  hasStaff,
+} from '../../src/lib/schedule-utils';
+import {
+  mockFullSchedule,
+  mockEmptySchedule,
+  mockFirstWeekOnly,
+  mockGameWeek,
+  mockSuspendedWeek,
+  mockFinishedGame,
+} from '../fixtures/schedule';
+
+describe('schedule-utils', () => {
+  // Covers: U-4 getCurrentWeek 邏輯
+  describe('getCurrentWeek', () => {
+    it('回傳 currentWeek 對應的 week 物件', () => {
+      const data = mockFullSchedule(); // currentWeek = 5
+      const week = getCurrentWeek(data);
+      expect(week).not.toBeNull();
+      expect(week?.type).toBe('game');
+      if (week?.type === 'game') expect(week.week).toBe(5);
+    });
+
+    it('currentWeek 找不到對應 week → 回傳 null', () => {
+      const data = { season: 25, currentWeek: 99, allWeeks: [mockGameWeek(1, '2026/1/10')] };
+      expect(getCurrentWeek(data)).toBeNull();
+    });
+
+    it('allWeeks 為空 → 回傳 null', () => {
+      expect(getCurrentWeek(mockEmptySchedule())).toBeNull();
+    });
+  });
+
+  // Covers: U-3 找上一個有資料週的邏輯
+  describe('findPreviousWeekWithData', () => {
+    it('從 W6 往回找，跳過 suspended → 回傳 W5', () => {
+      const data = mockFullSchedule();
+      const prev = findPreviousWeekWithData(data, 6);
+      expect(prev?.type).toBe('game');
+      if (prev?.type === 'game') expect(prev.week).toBe(5);
+    });
+
+    it('第 1 週往回找 → 回傳 null', () => {
+      const data = mockFirstWeekOnly();
+      expect(findPreviousWeekWithData(data, 1)).toBeNull();
+    });
+
+    it('完全沒有 game 週 → 回傳 null', () => {
+      const data = { season: 25, currentWeek: 1, allWeeks: [mockSuspendedWeek('2026/1/1', 'X')] };
+      expect(findPreviousWeekWithData(data, 1)).toBeNull();
+    });
+  });
+
+  // Covers: U-1 平手場次處理 + U-5 比分判斷
+  describe('getWinner', () => {
+    it('home 比分高 → home', () => {
+      const game = mockFinishedGame('紅', '白', 34, 22);
+      expect(getWinner(game)).toBe('home');
+    });
+
+    it('away 比分高 → away', () => {
+      const game = mockFinishedGame('紅', '白', 22, 34);
+      expect(getWinner(game)).toBe('away');
+    });
+
+    it('比分相同 → tie', () => {
+      const game = mockFinishedGame('紅', '白', 22, 22);
+      expect(getWinner(game)).toBe('tie');
+    });
+
+    it('未完賽（比分 null）→ none', () => {
+      const game = { num: 1, time: '', home: '紅', away: '白', homeScore: null, awayScore: null, status: 'upcoming' as const, staff: {} };
+      expect(getWinner(game)).toBe('none');
+    });
+  });
+
+  // Covers: U-6 suspended week 偵測
+  describe('isSuspended', () => {
+    it('suspended week → true', () => {
+      expect(isSuspended(mockSuspendedWeek('2026/2/14', '過年'))).toBe(true);
+    });
+
+    it('game week → false', () => {
+      expect(isSuspended(mockGameWeek(1, '2026/1/10'))).toBe(false);
+    });
+  });
+
+  // Covers: U-2 無 staff 資料時 toggle 邏輯
+  describe('hasStaff', () => {
+    it('staff 物件有任一非空陣列 → true', () => {
+      expect(hasStaff({ 裁判: ['李昊明(黑)'], 場務: [] })).toBe(true);
+    });
+
+    it('staff 物件全空 → false', () => {
+      expect(hasStaff({ 裁判: [], 場務: [] })).toBe(false);
+    });
+
+    it('staff 為空物件 → false', () => {
+      expect(hasStaff({})).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+npm test tests/unit/schedule-utils.test.ts
+```
+預期：FAIL — 模組不存在或函式未匯出
+
+- [ ] **Step 3：實作型別**
+
+```typescript
+// src/types/schedule.ts
+export type GameStatus = 'finished' | 'upcoming' | 'in_progress';
+
+export interface Game {
+  num: number;
+  time: string;
+  home: string;
+  away: string;
+  homeScore: number | null;
+  awayScore: number | null;
+  status: GameStatus;
+  staff: Record<string, string[]>;
+}
+
+export interface GameWeek {
+  type: 'game';
+  week: number;
+  date: string;
+  phase: string;
+  venue: string;
+  matchups: Array<{ combo: number; home: string; away: string; homeScore: number | null; awayScore: number | null; status: string }>;
+  games: Game[];
+}
+
+export interface SuspendedWeek {
+  type: 'suspended';
+  date: string;
+  venue: string;
+  reason: string;
+}
+
+export type ScheduleWeek = GameWeek | SuspendedWeek;
+
+export interface ScheduleData {
+  season: number;
+  currentWeek: number;
+  allWeeks: ScheduleWeek[];
+  weeks?: Record<string, GameWeek>;
+}
+
+export type Winner = 'home' | 'away' | 'tie' | 'none';
+```
+
+- [ ] **Step 4：實作 utils**
+
+```typescript
+// src/lib/schedule-utils.ts
+import type { Game, GameWeek, ScheduleData, ScheduleWeek, SuspendedWeek, Winner } from '../types/schedule';
+
+export function getCurrentWeek(data: ScheduleData): GameWeek | null {
+  const found = data.allWeeks.find(
+    (w): w is GameWeek => w.type === 'game' && w.week === data.currentWeek,
+  );
+  return found ?? null;
+}
+
+export function findPreviousWeekWithData(data: ScheduleData, fromWeek: number): GameWeek | null {
+  for (let i = data.allWeeks.length - 1; i >= 0; i--) {
+    const w = data.allWeeks[i];
+    if (w.type === 'game' && w.week < fromWeek) return w;
+  }
+  return null;
+}
+
+export function getWinner(game: Game): Winner {
+  if (game.homeScore == null || game.awayScore == null) return 'none';
+  if (game.homeScore > game.awayScore) return 'home';
+  if (game.awayScore > game.homeScore) return 'away';
+  return 'tie';
+}
+
+export function isSuspended(week: ScheduleWeek): week is SuspendedWeek {
+  return week.type === 'suspended';
+}
+
+export function hasStaff(staff: Record<string, string[]>): boolean {
+  return Object.values(staff).some((arr) => arr.length > 0);
+}
+```
+
+- [ ] **Step 5：確認測試通過**
+
+```bash
+npm test tests/unit/schedule-utils.test.ts
+```
+預期：PASS — 13 個 case 全綠
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add src/types/schedule.ts src/lib/schedule-utils.ts tests/unit/schedule-utils.test.ts
+git commit -m "feat(schedule): types + utils with unit tests (#1)"
+```
+
+---
+
+## Task 3：State 元件（Skeleton / Error / Empty）
+
+**Files:**
+- Create: `src/components/schedule/SkeletonState.tsx`
+- Create: `src/components/schedule/ErrorState.tsx`
+- Create: `src/components/schedule/EmptyState.tsx`
+
+- [ ] **Step 1：實作 SkeletonState**
+
+```tsx
+// src/components/schedule/SkeletonState.tsx
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse">
+      {/* Hero skeleton */}
+      <div className="text-center mb-6">
+        <div className="h-10 w-40 bg-gray-200 rounded mx-auto mb-3" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+
+      {/* Chip timeline skeleton */}
+      <div className="flex gap-2 overflow-x-auto mb-6 pb-2" data-testid="skeleton-chip">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="h-9 w-12 md:w-20 bg-gray-200 rounded-lg flex-shrink-0" />
+        ))}
+      </div>
+
+      {/* Cards skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-32 bg-gray-200 rounded-2xl" data-testid="skeleton-card" />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2：實作 ErrorState**
+
+```tsx
+// src/components/schedule/ErrorState.tsx
+interface Props {
+  onRetry: () => void;
+  message?: string;
+}
+
+export function ErrorState({ onRetry, message = '無法載入賽程' }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">{message}</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3：實作 EmptyState**
+
+```tsx
+// src/components/schedule/EmptyState.tsx
+interface Props {
+  onPrevWeek?: () => void;
+  prevDisabled?: boolean;
+  message?: string;
+}
+
+export function EmptyState({ onPrevWeek, prevDisabled = false, message = '本週無賽程，下週見' }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⛹️</div>
+      <p className="text-lg text-txt-dark mb-6">{message}</p>
+      {onPrevWeek && !prevDisabled && (
+        <button
+          onClick={onPrevWeek}
+          disabled={prevDisabled}
+          className="px-6 py-2 bg-navy text-white rounded-lg font-bold hover:bg-navy-2 transition disabled:opacity-40"
+        >
+          看上一週
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4：型別檢查**
+
+```bash
+npx astro check
+```
+預期：0 errors, 0 warnings
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/schedule/SkeletonState.tsx src/components/schedule/ErrorState.tsx src/components/schedule/EmptyState.tsx
+git commit -m "feat(schedule): loading/error/empty state components (#1)"
+```
+
+---
+
+## Task 4：ChipTimeline + SuspendedChip
+
+**Files:**
+- Create: `src/components/schedule/ChipTimeline.tsx`
+
+- [ ] **Step 1：實作 ChipTimeline**
+
+```tsx
+// src/components/schedule/ChipTimeline.tsx
+import { useState } from 'react';
+import type { ScheduleWeek, GameWeek, SuspendedWeek } from '../../types/schedule';
+import { isSuspended } from '../../lib/schedule-utils';
+
+interface Props {
+  weeks: ScheduleWeek[];
+  activeWeek: number;
+  onSelect: (week: number) => void;
+}
+
+export function ChipTimeline({ weeks, activeWeek, onSelect }: Props) {
+  const [popoverIdx, setPopoverIdx] = useState<number | null>(null);
+
+  return (
+    <div className="relative">
+      <div
+        className="flex gap-2 overflow-x-auto pb-2 px-4 md:px-8 scrollbar-thin"
+        role="tablist"
+        aria-label="賽程週次時間軸"
+      >
+        {weeks.map((week, idx) => {
+          if (isSuspended(week)) {
+            return (
+              <SuspendedChip
+                key={`s-${idx}`}
+                week={week}
+                isOpen={popoverIdx === idx}
+                onToggle={() => setPopoverIdx(popoverIdx === idx ? null : idx)}
+              />
+            );
+          }
+          const isActive = week.week === activeWeek;
+          return (
+            <button
+              key={`w-${week.week}`}
+              role="tab"
+              aria-selected={isActive}
+              data-testid="chip-week"
+              data-active={isActive}
+              onClick={() => onSelect(week.week)}
+              className={[
+                'flex-shrink-0 px-3 md:px-4 py-2 rounded-lg font-condensed font-bold transition whitespace-nowrap',
+                isActive
+                  ? 'bg-orange text-white'
+                  : 'bg-warm-1 text-txt-mid hover:bg-warm-2',
+              ].join(' ')}
+            >
+              <span className="md:hidden">W{week.week}</span>
+              <span className="hidden md:inline">W{week.week} · {formatShortDate(week.date)}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SuspendedChip({
+  week,
+  isOpen,
+  onToggle,
+}: {
+  week: SuspendedWeek;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="relative flex-shrink-0">
+      <button
+        data-testid="chip-suspended"
+        aria-label={`暫停週：${week.reason}`}
+        onClick={onToggle}
+        className="px-3 py-2 rounded-lg bg-gray-200 text-gray-500 font-condensed text-sm hover:bg-gray-300 transition whitespace-nowrap"
+      >
+        休
+      </button>
+      {isOpen && (
+        <div
+          role="tooltip"
+          className="absolute z-50 top-full mt-2 left-0 bg-navy text-white text-sm px-3 py-2 rounded-lg shadow-xl whitespace-nowrap"
+        >
+          {formatShortDate(week.date)} · {week.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatShortDate(date: string): string {
+  // "2026/2/7" → "2/7"
+  const parts = date.split('/');
+  return parts.length === 3 ? `${parts[1]}/${parts[2]}` : date;
+}
+```
+
+- [ ] **Step 2：型別檢查**
+
+```bash
+npx astro check
+```
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add src/components/schedule/ChipTimeline.tsx
+git commit -m "feat(schedule): ChipTimeline with suspended chip popover (#1)"
+```
+
+---
+
+## Task 5：GameCard + StaffPanel（TDD：U-2 staff toggle）
+
+**Files:**
+- Create: `src/components/schedule/GameCard.tsx`
+- Create: `tests/unit/staff-display.test.ts`
+
+- [ ] **Step 1：寫失敗測試**
+
+```typescript
+// tests/unit/staff-display.test.ts
+import { describe, it, expect } from 'vitest';
+import { hasStaff } from '../../src/lib/schedule-utils';
+import { mockFinishedGame } from '../fixtures/schedule';
+
+describe('staff display logic (U-2)', () => {
+  it('沒有 staff 資料 → toggle 不應該顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, {});
+    expect(hasStaff(game.staff)).toBe(false);
+  });
+
+  it('有 staff 資料（裁判 + 場務）→ toggle 應顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, {
+      裁判: ['李昊明(黑)'],
+      場務: ['林毅豐(黑)'],
+    });
+    expect(hasStaff(game.staff)).toBe(true);
+  });
+
+  it('staff 物件存在但所有 key 都是空陣列 → toggle 不應顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, { 裁判: [], 場務: [] });
+    expect(hasStaff(game.staff)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+npm test tests/unit/staff-display.test.ts
+```
+預期：先 PASS（hasStaff 已在 Task 2 實作），驗證 Task 2 邏輯支援 GameCard 需求
+
+- [ ] **Step 3：實作 GameCard**
+
+```tsx
+// src/components/schedule/GameCard.tsx
+import { useState } from 'react';
+import type { Game } from '../../types/schedule';
+import { getWinner, hasStaff } from '../../lib/schedule-utils';
+
+const TEAM_COLOR_CLASS: Record<string, string> = {
+  紅: 'bg-team-red',
+  黑: 'bg-team-black',
+  藍: 'bg-team-blue',
+  綠: 'bg-team-green',
+  黃: 'bg-team-yellow',
+  白: 'bg-team-white',
+};
+
+const STAFF_LABELS: Record<string, string> = {
+  裁判: '裁判',
+  場務: '場務',
+  攝影: '攝影',
+  器材: '器材',
+};
+
+interface Props {
+  game: Game;
+  baseUrl: string;
+}
+
+export function GameCard({ game, baseUrl }: Props) {
+  const [staffOpen, setStaffOpen] = useState(false);
+  const winner = getWinner(game);
+  const isFinished = game.status === 'finished';
+  const showStaffToggle = hasStaff(game.staff);
+  const staffCount = Object.values(game.staff).reduce((n, arr) => n + arr.length, 0);
+
+  const handleClick = () => {
+    if (isFinished) {
+      window.location.href = `${baseUrl.replace(/\/$/, '')}/boxscore`;
+    }
+  };
+
+  return (
+    <article
+      data-testid="game-card"
+      data-status={game.status}
+      onClick={handleClick}
+      className={[
+        'bg-white rounded-2xl border border-warm-2 p-4 md:p-5 transition-all',
+        isFinished ? 'cursor-pointer hover:shadow-lg hover:-translate-y-0.5' : 'cursor-default',
+      ].join(' ')}
+    >
+      {/* 對戰：兩隊 + 比分 */}
+      <div className="flex items-center justify-between mb-3">
+        <TeamSide team={game.home} score={game.homeScore} isWinner={winner === 'home'} testid="home" />
+        <div className="text-txt-light text-xs font-condensed mx-2">VS</div>
+        <TeamSide team={game.away} score={game.awayScore} isWinner={winner === 'away'} testid="away" reverse />
+      </div>
+
+      <div className="border-t border-warm-2 pt-3 flex items-center justify-between">
+        <StatusBadge status={game.status} />
+        {showStaffToggle && (
+          <button
+            data-testid="staff-toggle"
+            aria-label={staffOpen ? '收起工作人員' : '展開工作人員'}
+            aria-expanded={staffOpen}
+            onClick={(e) => {
+              e.stopPropagation();
+              setStaffOpen((prev) => !prev);
+            }}
+            className="text-sm text-txt-mid hover:text-orange transition flex items-center gap-1"
+          >
+            <span aria-hidden="true">👨‍⚖️</span>
+            <span>{staffCount}</span>
+            <span aria-hidden="true">{staffOpen ? '▲' : '▼'}</span>
+          </button>
+        )}
+      </div>
+
+      {staffOpen && showStaffToggle && (
+        <div data-testid="staff-panel" className="mt-3 pt-3 border-t border-warm-2 space-y-1 text-sm">
+          {Object.entries(game.staff).map(([role, names]) =>
+            names.length > 0 ? (
+              <div key={role} className="flex gap-2">
+                <span className="text-txt-light font-bold w-12">{STAFF_LABELS[role] ?? role}</span>
+                <span className="text-txt-mid">{names.join('、')}</span>
+              </div>
+            ) : null,
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function TeamSide({
+  team,
+  score,
+  isWinner,
+  testid,
+  reverse = false,
+}: {
+  team: string;
+  score: number | null;
+  isWinner: boolean;
+  testid: 'home' | 'away';
+  reverse?: boolean;
+}) {
+  const colorClass = TEAM_COLOR_CLASS[team] ?? 'bg-gray-400';
+  return (
+    <div
+      className={`flex-1 flex ${reverse ? 'flex-row-reverse text-right' : 'flex-row'} items-center gap-2`}
+      data-winner={isWinner}
+    >
+      <div className={`w-3 h-3 rounded-full ${colorClass} flex-shrink-0`} aria-hidden="true" />
+      <div className="flex flex-col">
+        <div className="font-condensed text-sm text-txt-mid">{team}隊</div>
+        <div
+          data-testid={`score-${testid}`}
+          className={`font-display text-2xl md:text-3xl ${isWinner ? 'text-orange font-extrabold' : 'text-txt-dark'}`}
+        >
+          {score == null ? '—' : score}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: Game['status'] }) {
+  const label = status === 'finished' ? '完賽' : '即將進行';
+  const colorClass =
+    status === 'finished'
+      ? 'bg-warm-2 text-txt-mid'
+      : 'bg-orange-light text-orange';
+  return (
+    <span
+      data-testid="status-badge"
+      className={`px-2 py-0.5 rounded text-xs font-condensed font-bold ${colorClass}`}
+    >
+      {label}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4：執行 unit test**
+
+```bash
+npm test tests/unit/staff-display.test.ts
+```
+預期：PASS
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/schedule/GameCard.tsx tests/unit/staff-display.test.ts
+git commit -m "feat(schedule): GameCard with staff expand and winner highlight (#1)"
+```
+
+---
+
+## Task 6：ScheduleHero
+
+**Files:**
+- Create: `src/components/schedule/ScheduleHero.tsx`
+
+- [ ] **Step 1：實作**
+
+```tsx
+// src/components/schedule/ScheduleHero.tsx
+import type { GameWeek } from '../../types/schedule';
+
+interface Props {
+  week: GameWeek;
+}
+
+export function ScheduleHero({ week }: Props) {
+  return (
+    <header className="text-center px-4 py-6 md:py-10">
+      <div className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        WEEK {week.week} · {week.phase}
+      </div>
+      <div className="font-condensed text-base md:text-lg text-txt-mid flex items-center justify-center gap-2">
+        <span>{formatDate(week.date)}</span>
+        <span aria-hidden="true">·</span>
+        <span className="flex items-center gap-1">
+          <span aria-hidden="true">📍</span>
+          <span>{week.venue}</span>
+        </span>
+      </div>
+    </header>
+  );
+}
+
+function formatDate(date: string): string {
+  // "2026/2/7" → "2026/2/7"（直接顯示，未來可改 i18n）
+  return date;
+}
+```
+
+- [ ] **Step 2：型別檢查**
+
+```bash
+npx astro check
+```
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add src/components/schedule/ScheduleHero.tsx
+git commit -m "feat(schedule): ScheduleHero header (#1)"
+```
+
+---
+
+## Task 7：ScheduleApp 主 island（狀態管理 + 組裝）
+
+**Files:**
+- Create: `src/components/schedule/ScheduleApp.tsx`
+
+- [ ] **Step 1：實作**
+
+```tsx
+// src/components/schedule/ScheduleApp.tsx
+import { useEffect, useState, useCallback } from 'react';
+import type { ScheduleData, GameWeek } from '../../types/schedule';
+import { fetchData } from '../../lib/api';
+import { getCurrentWeek, findPreviousWeekWithData, isSuspended } from '../../lib/schedule-utils';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { ScheduleHero } from './ScheduleHero';
+import { ChipTimeline } from './ChipTimeline';
+import { GameCard } from './GameCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function ScheduleApp({ baseUrl }: Props) {
+  const [data, setData] = useState<ScheduleData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [activeWeek, setActiveWeek] = useState<number | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<ScheduleData>('schedule');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const sched = result.data;
+      setData(sched);
+
+      if (sched.allWeeks.length === 0) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+
+      // 找 currentWeek 對應週
+      const current = getCurrentWeek(sched);
+      if (!current) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+
+      setActiveWeek(current.week);
+      setStatus('ok');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  const handlePrevWeek = useCallback(() => {
+    if (!data || activeWeek == null) return;
+    const prev = findPreviousWeekWithData(data, activeWeek);
+    if (prev) {
+      setActiveWeek(prev.week);
+      setStatus('ok');
+    }
+  }, [data, activeWeek]);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+  if (status === 'empty' || !data || activeWeek == null) {
+    const prevExists = data ? findPreviousWeekWithData(data, data.currentWeek) != null : false;
+    return <EmptyState onPrevWeek={handlePrevWeek} prevDisabled={!prevExists} />;
+  }
+
+  // 找 active week 物件
+  const activeWeekObj = data.allWeeks.find(
+    (w): w is GameWeek => w.type === 'game' && w.week === activeWeek,
+  );
+
+  if (!activeWeekObj) {
+    return <EmptyState onPrevWeek={handlePrevWeek} prevDisabled={false} />;
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8">
+      <ScheduleHero week={activeWeekObj} />
+      <ChipTimeline
+        weeks={data.allWeeks}
+        activeWeek={activeWeek}
+        onSelect={(w) => setActiveWeek(w)}
+      />
+      <section className="px-4 md:px-8 mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
+        {activeWeekObj.games.map((game) => (
+          <GameCard key={game.num} game={game} baseUrl={baseUrl} />
+        ))}
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2：型別檢查**
+
+```bash
+npx astro check
+```
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add src/components/schedule/ScheduleApp.tsx
+git commit -m "feat(schedule): ScheduleApp main island with state management (#1)"
+```
+
+---
+
+## Task 8：頁面整合 + E2E 驗證
+
+**Files:**
+- Modify: `src/pages/schedule.astro`
+
+- [ ] **Step 1：替換 stub 內容**
+
+```astro
+---
+// src/pages/schedule.astro
+import Layout from '../layouts/Layout.astro';
+import { ScheduleApp } from '../components/schedule/ScheduleApp';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<Layout title="本週賽程" active="schedule">
+  <ScheduleApp client:load baseUrl={baseUrl} />
+</Layout>
+```
+
+- [ ] **Step 2：本地驗證 dev server**
+
+```bash
+npm run dev
+# 開瀏覽器 http://localhost:4321/taan-basketball-league/schedule
+# 觀察：Hero header / chip timeline / 6 張卡片 / 切週 / 展開 staff
+```
+預期：手動驗收正常顯示資料
+
+- [ ] **Step 3：build 通過**
+
+```bash
+npm run build
+```
+預期：build 成功
+
+- [ ] **Step 4：跑全部 unit + integration**
+
+```bash
+npm test
+```
+預期：所有 unit + integration test 通過
+
+- [ ] **Step 5：跑 E2E（features + regression）**
+
+```bash
+npm run test:e2e -- --project=features --project=regression --project=regression-mobile
+```
+預期：schedule.spec.ts 所有 case 通過
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add src/pages/schedule.astro
+git commit -m "feat(schedule): integrate ScheduleApp into /schedule page (#1)"
+```
+
+---
+
+## 自我審查檢查清單
+
+- [x] 所有 qaplan U-* 都對應到 Task（U-1/3/4/5/6 → Task 2; U-2 → Task 5）
+- [x] 所有 Task Step 都有完整程式碼，無 TODO 佔位
+- [x] 整合測試已存在於 `tests/integration/api-fallback.integration.test.ts` 並通過 — 不需新建
+- [x] E2E 測試已存在於 `tests/e2e/features/schedule.spec.ts` — Task 8 驗證跑通
+- [x] 並行群組標明：B = {3, 4, 5, 6}
+- [x] Tasks 自完備，無「參考 Task X」的指代
+
+## Phase 2 執行注意事項
+
+- 使用 `superpowers:dispatching-parallel-agents` 同時 dispatch Task 3、4、5、6（Task 2 完成後）
+- 各 task 獨立 commit，不要 squash
+- 每個 task 完成 → pm-v2 per-task review → 通過才進下一個
+- 全部 task 完成後才跑整合（Phase 3）

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,18 @@
       "name": "taan-basketball-league",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/react": "^5.0.4",
         "@tailwindcss/vite": "^4.2.4",
         "astro": "^6.2.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitest/ui": "^4.1.5",
         "jsdom": "^29.1.1",
         "vitest": "^4.1.5"
@@ -130,6 +135,28 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@astrojs/react": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.4.tgz",
+      "integrity": "sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.9.0",
+        "@vitejs/plugin-react": "^5.2.0",
+        "devalue": "^5.6.4",
+        "ultrahtml": "^1.6.0",
+        "vite": "^7.3.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
@@ -145,6 +172,166 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -165,6 +352,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
@@ -178,6 +387,68 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1370,6 +1641,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -2081,6 +2358,47 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2157,6 +2475,24 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2168,6 +2504,26 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -2470,6 +2826,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2485,6 +2853,59 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2607,7 +3028,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2711,6 +3131,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2903,6 +3329,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.348",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
+      "integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
@@ -2973,6 +3405,15 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3112,6 +3553,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/github-slugger": {
@@ -3455,6 +3905,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3532,6 +3988,30 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -4693,6 +5173,12 @@
       "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4977,6 +5463,36 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
@@ -5293,6 +5809,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -5952,6 +6474,36 @@
         }
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -6283,6 +6835,12 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,18 @@
     "audit:folders": "bash scripts/folder-audit.sh"
   },
   "dependencies": {
+    "@astrojs/react": "^5.0.4",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^6.2.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitest/ui": "^4.1.5",
     "jsdom": "^29.1.1",
     "vitest": "^4.1.5"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const BASE_URL = process.env.BASE_URL ?? 'http://localhost:4321/taan-basketball-league';
+// baseURL 結尾必須有 /，否則 page.goto('/path') 的 leading 斜線會覆蓋 path component（→ 404）
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:4321/taan-basketball-league/';
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -31,6 +32,12 @@ export default defineConfig({
       testMatch: /.*\.spec\.ts/,
       testIgnore: /.*\.regression\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'features-mobile',
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: /.*\.regression\.spec\.ts/,
+      use: { ...devices['Pixel 7'] }, // 手機 viewport 測 RWD
     },
   ],
   webServer: {

--- a/src/components/schedule/ChipTimeline.tsx
+++ b/src/components/schedule/ChipTimeline.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import type { ScheduleWeek, SuspendedWeek } from '../../types/schedule';
+import { isSuspended } from '../../lib/schedule-utils';
+
+interface Props {
+  weeks: ScheduleWeek[];
+  activeWeek: number;
+  onSelect: (week: number) => void;
+}
+
+export function ChipTimeline({ weeks, activeWeek, onSelect }: Props) {
+  const [popoverIdx, setPopoverIdx] = useState<number | null>(null);
+
+  return (
+    <div className="relative">
+      <div
+        className="flex gap-2 overflow-x-auto pb-2 px-4 md:px-8 scrollbar-thin"
+        role="tablist"
+        aria-label="賽程週次時間軸"
+      >
+        {weeks.map((week, idx) => {
+          if (isSuspended(week)) {
+            return (
+              <SuspendedChipBtn
+                key={`s-${idx}`}
+                week={week}
+                isOpen={popoverIdx === idx}
+                onToggle={() =>
+                  setPopoverIdx((prev) => (prev === idx ? null : idx))
+                }
+              />
+            );
+          }
+          const isActive = week.week === activeWeek;
+          return (
+            <button
+              key={`w-${week.week}`}
+              role="tab"
+              aria-selected={isActive}
+              data-testid="chip-week"
+              data-active={isActive}
+              data-week={week.week}
+              onClick={() => {
+                setPopoverIdx(null);
+                onSelect(week.week);
+              }}
+              className={[
+                'flex-shrink-0 px-3 md:px-4 py-2 rounded-lg font-condensed font-bold transition whitespace-nowrap',
+                isActive
+                  ? 'bg-orange text-white'
+                  : 'bg-warm-1 text-txt-mid hover:bg-warm-2',
+              ].join(' ')}
+            >
+              <span className="md:hidden">W{week.week}</span>
+              <span className="hidden md:inline">
+                W{week.week} · {formatShortDate(week.date)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SuspendedChipBtn({
+  week,
+  isOpen,
+  onToggle,
+}: {
+  week: SuspendedWeek;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="relative flex-shrink-0">
+      <button
+        data-testid="chip-suspended"
+        aria-label={`暫停週：${week.reason}`}
+        aria-expanded={isOpen}
+        onClick={onToggle}
+        className="px-3 py-2 rounded-lg bg-gray-200 text-gray-500 font-condensed text-sm hover:bg-gray-300 transition whitespace-nowrap"
+      >
+        休
+      </button>
+      {isOpen && (
+        <div
+          role="tooltip"
+          className="absolute z-50 top-full mt-2 left-0 bg-navy text-white text-sm px-3 py-2 rounded-lg shadow-xl whitespace-nowrap"
+        >
+          {formatShortDate(week.date)} · {week.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatShortDate(date: string): string {
+  const parts = date.split('/');
+  return parts.length === 3 ? `${parts[1]}/${parts[2]}` : date;
+}

--- a/src/components/schedule/EmptyState.tsx
+++ b/src/components/schedule/EmptyState.tsx
@@ -1,0 +1,29 @@
+interface Props {
+  onPrevWeek?: () => void;
+  prevDisabled?: boolean;
+  message?: string;
+}
+
+export function EmptyState({
+  onPrevWeek,
+  prevDisabled = false,
+  message = '本週無賽程，下週見',
+}: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">
+        ⛹️
+      </div>
+      <p className="text-lg text-txt-dark mb-6">{message}</p>
+      {onPrevWeek && !prevDisabled && (
+        <button
+          onClick={onPrevWeek}
+          disabled={prevDisabled}
+          className="px-6 py-2 bg-navy text-white rounded-lg font-bold hover:bg-navy-2 transition disabled:opacity-40"
+        >
+          看上一週
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/schedule/ErrorState.tsx
+++ b/src/components/schedule/ErrorState.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  onRetry: () => void;
+  message?: string;
+}
+
+export function ErrorState({ onRetry, message = '無法載入賽程' }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">
+        ⚠️
+      </div>
+      <p className="text-lg text-txt-dark mb-2">{message}</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}

--- a/src/components/schedule/GameCard.tsx
+++ b/src/components/schedule/GameCard.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import type { Game } from '../../types/schedule';
+import { getWinner, hasStaff } from '../../lib/schedule-utils';
+
+const TEAM_COLOR_CLASS: Record<string, string> = {
+  紅: 'bg-team-red',
+  黑: 'bg-team-black',
+  藍: 'bg-team-blue',
+  綠: 'bg-team-green',
+  黃: 'bg-team-yellow',
+  白: 'bg-team-white',
+};
+
+const STAFF_LABELS: Record<string, string> = {
+  裁判: '裁判',
+  場務: '場務',
+  攝影: '攝影',
+  器材: '器材',
+};
+
+interface Props {
+  game: Game;
+  baseUrl: string;
+}
+
+export function GameCard({ game, baseUrl }: Props) {
+  const [staffOpen, setStaffOpen] = useState(false);
+  const winner = getWinner(game);
+  const isFinished = game.status === 'finished';
+  const showStaffToggle = hasStaff(game.staff);
+  const staffCount = Object.values(game.staff).reduce(
+    (n, arr) => n + arr.length,
+    0,
+  );
+
+  const handleClick = () => {
+    if (isFinished) {
+      const target = `${baseUrl.replace(/\/$/, '')}/boxscore`;
+      window.location.href = target;
+    }
+  };
+
+  return (
+    <article
+      data-testid="game-card"
+      data-status={game.status}
+      onClick={handleClick}
+      className={[
+        'bg-white rounded-2xl border border-warm-2 p-4 md:p-5 transition-all',
+        isFinished
+          ? 'cursor-pointer hover:shadow-lg hover:-translate-y-0.5'
+          : 'cursor-default',
+      ].join(' ')}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <TeamSide
+          team={game.home}
+          score={game.homeScore}
+          isWinner={winner === 'home'}
+          testid="home"
+        />
+        <div className="text-txt-light text-xs font-condensed mx-2">VS</div>
+        <TeamSide
+          team={game.away}
+          score={game.awayScore}
+          isWinner={winner === 'away'}
+          testid="away"
+          reverse
+        />
+      </div>
+
+      <div className="border-t border-warm-2 pt-3 flex items-center justify-between">
+        <StatusBadge status={game.status} />
+        {showStaffToggle && (
+          <button
+            data-testid="staff-toggle"
+            aria-label={staffOpen ? '收起工作人員' : '展開工作人員'}
+            aria-expanded={staffOpen}
+            onClick={(e) => {
+              e.stopPropagation();
+              setStaffOpen((prev) => !prev);
+            }}
+            className="text-sm text-txt-mid hover:text-orange transition flex items-center gap-1"
+          >
+            <span aria-hidden="true">👨‍⚖️</span>
+            <span>{staffCount}</span>
+            <span aria-hidden="true">{staffOpen ? '▲' : '▼'}</span>
+          </button>
+        )}
+      </div>
+
+      {staffOpen && showStaffToggle && (
+        <div
+          data-testid="staff-panel"
+          className="mt-3 pt-3 border-t border-warm-2 space-y-1 text-sm"
+        >
+          {Object.entries(game.staff).map(([role, names]) =>
+            names.length > 0 ? (
+              <div key={role} className="flex gap-2">
+                <span className="text-txt-light font-bold w-12">
+                  {STAFF_LABELS[role] ?? role}
+                </span>
+                <span className="text-txt-mid">{names.join('、')}</span>
+              </div>
+            ) : null,
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function TeamSide({
+  team,
+  score,
+  isWinner,
+  testid,
+  reverse = false,
+}: {
+  team: string;
+  score: number | null;
+  isWinner: boolean;
+  testid: 'home' | 'away';
+  reverse?: boolean;
+}) {
+  const colorClass = TEAM_COLOR_CLASS[team] ?? 'bg-gray-400';
+  return (
+    <div
+      className={[
+        'flex-1 flex items-center gap-2',
+        reverse ? 'flex-row-reverse text-right' : 'flex-row',
+      ].join(' ')}
+      data-winner={isWinner}
+    >
+      <div
+        className={`w-3 h-3 rounded-full ${colorClass} flex-shrink-0`}
+        aria-hidden="true"
+      />
+      <div className="flex flex-col">
+        <div className="font-condensed text-sm text-txt-mid">{team}隊</div>
+        <div
+          data-testid={`score-${testid}`}
+          className={[
+            'font-display text-2xl md:text-3xl',
+            isWinner ? 'text-orange font-extrabold' : 'text-txt-dark',
+          ].join(' ')}
+        >
+          {score == null ? '—' : score}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: Game['status'] }) {
+  const label = status === 'finished' ? '完賽' : '即將進行';
+  const colorClass =
+    status === 'finished'
+      ? 'bg-warm-2 text-txt-mid'
+      : 'bg-orange-light text-orange';
+  return (
+    <span
+      data-testid="status-badge"
+      className={`px-2 py-0.5 rounded text-xs font-condensed font-bold ${colorClass}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/schedule/ScheduleApp.tsx
+++ b/src/components/schedule/ScheduleApp.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { ScheduleData, GameWeek } from '../../types/schedule';
+import { fetchData } from '../../lib/api';
+import {
+  getCurrentWeek,
+  findPreviousWeekWithData,
+} from '../../lib/schedule-utils';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { ScheduleHero } from './ScheduleHero';
+import { ChipTimeline } from './ChipTimeline';
+import { GameCard } from './GameCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function ScheduleApp({ baseUrl }: Props) {
+  const [data, setData] = useState<ScheduleData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [activeWeek, setActiveWeek] = useState<number | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<ScheduleData>('schedule');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const sched = result.data;
+      setData(sched);
+
+      if (sched.allWeeks.length === 0) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+
+      const current = getCurrentWeek(sched);
+      if (!current) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+
+      setActiveWeek(current.week);
+      setStatus('ok');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  const handlePrevWeek = useCallback(() => {
+    if (!data) return;
+    const fromWeek = activeWeek ?? data.currentWeek;
+    const prev = findPreviousWeekWithData(data, fromWeek);
+    if (prev) {
+      setActiveWeek(prev.week);
+      setStatus('ok');
+    }
+  }, [data, activeWeek]);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+
+  if (status === 'empty' || !data || activeWeek == null) {
+    const prevExists =
+      data != null &&
+      findPreviousWeekWithData(data, data.currentWeek) != null;
+    return (
+      <EmptyState onPrevWeek={handlePrevWeek} prevDisabled={!prevExists} />
+    );
+  }
+
+  const activeWeekObj = data.allWeeks.find(
+    (w): w is GameWeek => w.type === 'game' && w.week === activeWeek,
+  );
+
+  if (!activeWeekObj) {
+    return <EmptyState onPrevWeek={handlePrevWeek} prevDisabled={false} />;
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8">
+      <ScheduleHero week={activeWeekObj} />
+      <ChipTimeline
+        weeks={data.allWeeks}
+        activeWeek={activeWeek}
+        onSelect={(w) => setActiveWeek(w)}
+      />
+      <section className="px-4 md:px-8 mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 md:gap-4">
+        {activeWeekObj.games.map((game) => (
+          <GameCard key={game.num} game={game} baseUrl={baseUrl} />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/components/schedule/ScheduleHero.tsx
+++ b/src/components/schedule/ScheduleHero.tsx
@@ -1,0 +1,23 @@
+import type { GameWeek } from '../../types/schedule';
+
+interface Props {
+  week: GameWeek;
+}
+
+export function ScheduleHero({ week }: Props) {
+  return (
+    <header className="text-center px-4 py-6 md:py-10">
+      <h1 className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        WEEK {week.week} · {week.phase}
+      </h1>
+      <div className="font-condensed text-base md:text-lg text-txt-mid flex items-center justify-center gap-2">
+        <span>{week.date}</span>
+        <span aria-hidden="true">·</span>
+        <span className="flex items-center gap-1">
+          <span aria-hidden="true">📍</span>
+          <span>{week.venue}</span>
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/src/components/schedule/SkeletonState.tsx
+++ b/src/components/schedule/SkeletonState.tsx
@@ -1,0 +1,30 @@
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse">
+      <div className="text-center mb-6">
+        <div className="h-10 w-40 bg-gray-200 rounded mx-auto mb-3" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+
+      <div className="flex gap-2 overflow-x-auto mb-6 pb-2 px-4 md:px-8">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            data-testid="skeleton-chip"
+            className="h-9 w-12 md:w-20 bg-gray-200 rounded-lg flex-shrink-0"
+          />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-4 md:px-8">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            data-testid="skeleton-card"
+            className="h-32 bg-gray-200 rounded-2xl"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ interface Props {
 const { title, description, active } = Astro.props;
 const pageTitle = title ? `${title}｜${SITE.shortName}` : SITE.name;
 const pageDesc = description ?? SITE.description;
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <!doctype html>
@@ -22,8 +23,8 @@ const pageDesc = description ?? SITE.description;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="description" content={pageDesc} />
-    <link rel="icon" type="image/png" href={`${import.meta.env.BASE_URL}icons/icon-192.png`} />
-    <link rel="manifest" href={`${import.meta.env.BASE_URL}manifest.json`} />
+    <link rel="icon" type="image/png" href={`${BASE}/icons/icon-192.png`} />
+    <link rel="manifest" href={`${BASE}/manifest.json`} />
     <meta name="theme-color" content="#0f1b2d" />
 
     <!-- 字型 -->
@@ -43,14 +44,14 @@ const pageDesc = description ?? SITE.description;
       class="sticky top-0 z-50 hidden md:flex items-center bg-navy h-[58px] px-6 shadow-md"
       aria-label="主選單"
     >
-      <a href={import.meta.env.BASE_URL} class="text-orange font-display text-[1.35rem] tracking-wider mr-6 whitespace-nowrap">
+      <a href={`${BASE}/`} class="text-orange font-display text-[1.35rem] tracking-wider mr-6 whitespace-nowrap">
         {SITE.shortName}
       </a>
       <ul class="flex flex-1 overflow-x-auto list-none gap-0">
         {NAV_ITEMS.map((item) => (
           <li>
             <a
-              href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}${item.href}`}
+              href={`${BASE}${item.href}`}
               class:list={[
                 'block px-4 leading-[58px] font-condensed text-sm font-bold tracking-wide whitespace-nowrap transition-colors border-b-[3px] border-transparent',
                 active === item.id
@@ -77,7 +78,7 @@ const pageDesc = description ?? SITE.description;
       <div class="flex items-stretch h-full min-w-max px-1">
         {NAV_ITEMS.map((item) => (
           <a
-            href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}${item.href}`}
+            href={`${BASE}${item.href}`}
             class:list={[
               'flex flex-col items-center justify-center px-4 gap-0.5 font-condensed text-[0.65rem] font-extrabold tracking-wide transition-colors',
               active === item.id ? 'text-orange' : 'text-white/60',
@@ -94,7 +95,7 @@ const pageDesc = description ?? SITE.description;
       // PWA Service Worker 註冊
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          const swPath = `${import.meta.env.BASE_URL}sw.js`;
+          const swPath = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/sw.js`;
           navigator.serviceWorker
             .register(swPath)
             .catch((err: unknown) => console.warn('[sw] register failed', err));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,7 +22,8 @@ export type DataKind =
   | 'hof';
 
 const GAS_URL = import.meta.env.PUBLIC_GAS_WEBAPP_URL;
-const STATIC_BASE = import.meta.env.BASE_URL ?? '/';
+const RAW_BASE = import.meta.env.BASE_URL ?? '/';
+const STATIC_BASE = RAW_BASE.replace(/\/$/, ''); // 去掉尾斜線，串接時統一補
 
 interface FetchResult<T> {
   data: T | null;
@@ -50,7 +51,7 @@ export async function fetchData<T = unknown>(kind: DataKind): Promise<FetchResul
 
   // Fallback 到靜態 JSON
   try {
-    const url = `${STATIC_BASE}data/${kind}.json`.replace(/\/+/g, '/');
+    const url = `${STATIC_BASE}/data/${kind}.json`;
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = (await res.json()) as T;

--- a/src/lib/schedule-utils.ts
+++ b/src/lib/schedule-utils.ts
@@ -1,0 +1,41 @@
+import type {
+  Game,
+  GameWeek,
+  ScheduleData,
+  ScheduleWeek,
+  SuspendedWeek,
+  Winner,
+} from '../types/schedule';
+
+export function getCurrentWeek(data: ScheduleData): GameWeek | null {
+  const found = data.allWeeks.find(
+    (w): w is GameWeek => w.type === 'game' && w.week === data.currentWeek,
+  );
+  return found ?? null;
+}
+
+export function findPreviousWeekWithData(
+  data: ScheduleData,
+  fromWeek: number,
+): GameWeek | null {
+  for (let i = data.allWeeks.length - 1; i >= 0; i--) {
+    const w = data.allWeeks[i];
+    if (w.type === 'game' && w.week < fromWeek) return w;
+  }
+  return null;
+}
+
+export function getWinner(game: Game): Winner {
+  if (game.homeScore == null || game.awayScore == null) return 'none';
+  if (game.homeScore > game.awayScore) return 'home';
+  if (game.awayScore > game.homeScore) return 'away';
+  return 'tie';
+}
+
+export function isSuspended(week: ScheduleWeek): week is SuspendedWeek {
+  return week.type === 'suspended';
+}
+
+export function hasStaff(staff: Record<string, string[]>): boolean {
+  return Object.values(staff).some((arr) => arr.length > 0);
+}

--- a/src/pages/schedule.astro
+++ b/src/pages/schedule.astro
@@ -1,15 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { ScheduleApp } from '../components/schedule/ScheduleApp';
+
+const baseUrl = import.meta.env.BASE_URL;
 ---
 
 <Layout title="本週賽程" active="schedule">
-  <section class="px-4 md:px-8 py-8 max-w-6xl mx-auto">
-    <h1 class="font-display text-3xl md:text-5xl text-navy tracking-wider mb-2">本週賽程</h1>
-    <p class="text-txt-mid mb-8">每週固定週六晚上 19:00 開戰，地點：大安國中 / 龍門國中</p>
-
-    <div class="bg-white border border-warm-2 rounded-2xl p-8 text-center">
-      <p class="font-condensed text-2xl text-orange mb-2">規劃中</p>
-      <p class="text-txt-mid text-sm">即將從 Google Sheets API 拉資料渲染</p>
-    </div>
-  </section>
+  <ScheduleApp client:load baseUrl={baseUrl} />
 </Layout>

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,47 @@
+export type GameStatus = 'finished' | 'upcoming' | 'in_progress';
+
+export interface Game {
+  num: number;
+  time: string;
+  home: string;
+  away: string;
+  homeScore: number | null;
+  awayScore: number | null;
+  status: GameStatus;
+  staff: Record<string, string[]>;
+}
+
+export interface GameWeek {
+  type: 'game';
+  week: number;
+  date: string;
+  phase: string;
+  venue: string;
+  matchups: Array<{
+    combo: number;
+    home: string;
+    away: string;
+    homeScore: number | null;
+    awayScore: number | null;
+    status: string;
+  }>;
+  games: Game[];
+}
+
+export interface SuspendedWeek {
+  type: 'suspended';
+  date: string;
+  venue: string;
+  reason: string;
+}
+
+export type ScheduleWeek = GameWeek | SuspendedWeek;
+
+export interface ScheduleData {
+  season: number;
+  currentWeek: number;
+  allWeeks: ScheduleWeek[];
+  weeks?: Record<string, GameWeek>;
+}
+
+export type Winner = 'home' | 'away' | 'tie' | 'none';

--- a/tests/e2e/features/schedule.spec.ts
+++ b/tests/e2e/features/schedule.spec.ts
@@ -18,7 +18,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-1: 預設顯示當前週 ──────
   test('AC-1: 預設顯示當前週的 Hero header + chip timeline + 6 張對戰卡片', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     // UI 結構
     await expect(page.getByRole('heading', { name: /WEEK\s*5/i })).toBeVisible();
@@ -38,10 +38,10 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-2: 切換週 ──────
   test('AC-2: 點擊另一週 chip → Hero header + 對戰卡片同步更新', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     // 互動
-    await page.locator('[data-testid="chip-week"]', { hasText: '1' }).first().click();
+    await page.locator('[data-testid="chip-week"][data-week="1"]').click();
 
     // UI 同步更新
     await expect(page.getByRole('heading', { name: /WEEK\s*1/i })).toBeVisible();
@@ -54,7 +54,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-3: 完賽場次比分顯示 + 贏家強調 ──────
   test('AC-3: 完賽場次顯示大字比分，贏家有視覺強調', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const firstCard = page.locator('[data-testid="game-card"]').first();
 
@@ -70,10 +70,10 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-4: 即將進行場次 ──────
   test('AC-4: 即將進行場次顯示「— vs —」+ 「即將進行」徽章', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     // 切到 W7（全部 upcoming）
-    await page.locator('[data-testid="chip-week"]', { hasText: '7' }).first().click();
+    await page.locator('[data-testid="chip-week"][data-week="7"]').click();
 
     const cards = page.locator('[data-testid="game-card"]');
     await expect(cards.first().locator('[data-testid="status-badge"]')).toContainText(/即將進行/);
@@ -83,7 +83,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-5: 完賽卡片可點 → 跳 /boxscore ──────
   test('AC-5: 點擊完賽卡片 → 導向 /boxscore', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const finishedCard = page.locator('[data-testid="game-card"][data-status="finished"]').first();
     await finishedCard.click();
@@ -94,8 +94,8 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-5 [qa-v2 補充]：upcoming 卡片不可點 ──────
   test('[qa-v2 補充] AC-5b: 即將進行場次不可點擊（cursor 非 pointer 或 click 無導航）', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
-    await page.locator('[data-testid="chip-week"]', { hasText: '7' }).first().click();
+    await page.goto('schedule');
+    await page.locator('[data-testid="chip-week"][data-week="7"]').click();
 
     const upcomingCard = page.locator('[data-testid="game-card"][data-status="upcoming"]').first();
     const cursor = await upcomingCard.evaluate((el) => getComputedStyle(el).cursor);
@@ -105,7 +105,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-6: 展開工作人員 ──────
   test('AC-6: 點卡片展開箭頭 → 顯示工作人員（裁判 / 場務 / 攝影 / 器材）', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const cardWithStaff = page.locator('[data-testid="game-card"]').first();
     await cardWithStaff.locator('[data-testid="staff-toggle"]').click();
@@ -118,7 +118,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-6 [qa-v2 補充]：再次點擊收起 ──────
   test('[qa-v2 補充] AC-6b: 再次點擊展開箭頭 → 工作人員面板收起', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const card = page.locator('[data-testid="game-card"]').first();
     const toggle = card.locator('[data-testid="staff-toggle"]');
@@ -134,7 +134,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-7: 暫停週 chip ──────
   test('AC-7: 點擊「休」chip → 顯示暫停原因', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const suspendedChip = page.locator('[data-testid="chip-suspended"]').first();
     await suspendedChip.click();
@@ -145,7 +145,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-14: 連續多週暫停 ──────
   test('AC-14: 連續 3 週暫停 → chip 列出現 3 個獨立「休」chip，皆可點開', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const suspendedChips = page.locator('[data-testid="chip-suspended"]');
     await expect(suspendedChips).toHaveCount(3);
@@ -158,10 +158,10 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-15: 混合場次 ──────
   test('AC-15: 同週 4 完賽 + 2 即將進行 → 各自正確渲染', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     // 切到 W6（mixed）
-    await page.locator('[data-testid="chip-week"]', { hasText: '6' }).first().click();
+    await page.locator('[data-testid="chip-week"][data-week="6"]').click();
 
     const finished = page.locator('[data-testid="game-card"][data-status="finished"]');
     const upcoming = page.locator('[data-testid="game-card"][data-status="upcoming"]');
@@ -172,7 +172,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-10: Loading state ──────
   test('AC-10: 資料載入中 → 看到 skeleton', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule(), { delayMs: 1500 });
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     // 進頁後立即（資料還沒回）skeleton 應出現
     await expect(page.locator('[data-testid="skeleton-chip"]').first()).toBeVisible();
@@ -186,7 +186,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-11: Error state ──────
   test('AC-11: GAS + JSON 都失敗 → 顯示「無法載入賽程」+ 重試按鈕', async ({ page }) => {
     await mockScheduleAPI(page, null, { allFail: true });
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     await expect(page.getByText(/無法載入賽程/)).toBeVisible();
     await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
@@ -200,10 +200,11 @@ test.describe('Schedule Page @schedule', () => {
       await route.fulfill({ status: 500, body: 'fail' });
     });
     await page.route(/\/data\/schedule\.json/, async (route) => {
+      callCount++;
       await route.fulfill({ status: 500, body: 'fail' });
     });
 
-    await page.goto('/schedule');
+    await page.goto('schedule');
     await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
 
     const initialCount = callCount;
@@ -216,7 +217,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-12: Empty state ──────
   test('AC-12: 該週無比賽 → 顯示「本週無賽程，下週見」+ 看上一週按鈕', async ({ page }) => {
     await mockScheduleAPI(page, mockCurrentWeekMissing());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     await expect(page.getByText(/本週無賽程/)).toBeVisible();
     await expect(page.getByRole('button', { name: /看上一週/ })).toBeVisible();
@@ -225,7 +226,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-13: 第 1 週邊界 ──────
   test('AC-13: 賽季第 1 週 + 空資料 → 「看上一週」按鈕禁用或隱藏', async ({ page }) => {
     await mockScheduleAPI(page, { season: 25, currentWeek: 1, allWeeks: [] });
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const button = page.getByRole('button', { name: /看上一週/ });
     const isHidden = (await button.count()) === 0;
@@ -237,7 +238,7 @@ test.describe('Schedule Page @schedule', () => {
   // ────── AC-7 [qa-v2 補充]：點休 chip 不應切到該週 ──────
   test('[qa-v2 補充] AC-7b: 點擊「休」chip 不會把 Hero header 換成「休」（不切該週）', async ({ page }) => {
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const headerBefore = await page.getByRole('heading', { level: 1 }).textContent();
     await page.locator('[data-testid="chip-suspended"]').first().click();
@@ -252,11 +253,11 @@ test.describe('Schedule Page RWD @schedule', () => {
   test('AC-8 (regression-mobile): 手機寬度 → chip 緊湊版「W5」、卡片直排', async ({ page, viewport }) => {
     test.skip(!viewport || viewport.width >= 768, 'mobile project only');
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const chip = page.locator('[data-testid="chip-week"]').first();
-    const text = (await chip.textContent()) ?? '';
-    expect(text.trim()).toMatch(/^W?\d+$/); // 緊湊版
+    const visibleText = await chip.evaluate((el) => (el as HTMLElement).innerText);
+    expect(visibleText.trim()).toMatch(/^W?\d+$/); // 緊湊版（mobile 只顯示 W{n}）
 
     // 卡片直排：第一張和第二張的 X 座標應接近（垂直排列）
     const cards = page.locator('[data-testid="game-card"]');
@@ -269,10 +270,11 @@ test.describe('Schedule Page RWD @schedule', () => {
   test('AC-9 (regression desktop): 桌機寬度 → chip 顯示「W5 · 2/7」、卡片並排', async ({ page, viewport }) => {
     test.skip(!viewport || viewport.width < 768, 'desktop project only');
     await mockScheduleAPI(page, mockFullSchedule());
-    await page.goto('/schedule');
+    await page.goto('schedule');
 
     const activeChip = page.locator('[data-testid="chip-week"][data-active="true"]');
-    await expect(activeChip).toContainText(/2.*7/); // 含日期
+    const visibleText = await activeChip.evaluate((el) => (el as HTMLElement).innerText);
+    expect(visibleText).toMatch(/2.*7/); // 桌機展開版含日期 2/7
 
     // 卡片兩兩並排：前兩張卡 Y 座標相近
     const cards = page.locator('[data-testid="game-card"]');

--- a/tests/e2e/features/schedule.spec.ts
+++ b/tests/e2e/features/schedule.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * /schedule 賽程頁 E2E
+ *
+ * Tag: @schedule
+ * Coverage: AC-1 ~ AC-15（全部）+ qa-v2 補充
+ *
+ * 測試資料策略：
+ * - 預設用 mockScheduleAPI() 攔截 GAS 與 fallback JSON 請求
+ * - 不會打 production Google Sheets
+ * - 各情境用 fixtures/schedule.ts 的工廠函式建立
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockFullSchedule, mockCurrentWeekMissing } from '../../fixtures/schedule';
+import { mockScheduleAPI } from '../../helpers/mock-api';
+
+test.describe('Schedule Page @schedule', () => {
+  // ────── AC-1: 預設顯示當前週 ──────
+  test('AC-1: 預設顯示當前週的 Hero header + chip timeline + 6 張對戰卡片', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    // UI 結構
+    await expect(page.getByRole('heading', { name: /WEEK\s*5/i })).toBeVisible();
+    await expect(page.getByText(/2026.*2.*7/)).toBeVisible();
+    await expect(page.getByText(/三重/)).toBeVisible();
+    await expect(page.getByText(/例行賽/)).toBeVisible();
+
+    // chip timeline：當前週應為 active 狀態
+    const activeChip = page.locator('[data-testid="chip-week"][data-active="true"]');
+    await expect(activeChip).toContainText('5');
+
+    // 6 張對戰卡片
+    const cards = page.locator('[data-testid="game-card"]');
+    await expect(cards).toHaveCount(6);
+  });
+
+  // ────── AC-2: 切換週 ──────
+  test('AC-2: 點擊另一週 chip → Hero header + 對戰卡片同步更新', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    // 互動
+    await page.locator('[data-testid="chip-week"]', { hasText: '1' }).first().click();
+
+    // UI 同步更新
+    await expect(page.getByRole('heading', { name: /WEEK\s*1/i })).toBeVisible();
+    await expect(page.getByText(/熱身賽/)).toBeVisible();
+
+    const cards = page.locator('[data-testid="game-card"]');
+    await expect(cards).toHaveCount(6);
+  });
+
+  // ────── AC-3: 完賽場次比分顯示 + 贏家強調 ──────
+  test('AC-3: 完賽場次顯示大字比分，贏家有視覺強調', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const firstCard = page.locator('[data-testid="game-card"]').first();
+
+    // 比分顯示
+    await expect(firstCard.locator('[data-testid="score-home"]')).toContainText(/\d+/);
+    await expect(firstCard.locator('[data-testid="score-away"]')).toContainText(/\d+/);
+
+    // 贏家視覺強調（data-winner 屬性 / class / aria）
+    const winner = firstCard.locator('[data-winner="true"]');
+    await expect(winner).toBeVisible();
+  });
+
+  // ────── AC-4: 即將進行場次 ──────
+  test('AC-4: 即將進行場次顯示「— vs —」+ 「即將進行」徽章', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    // 切到 W7（全部 upcoming）
+    await page.locator('[data-testid="chip-week"]', { hasText: '7' }).first().click();
+
+    const cards = page.locator('[data-testid="game-card"]');
+    await expect(cards.first().locator('[data-testid="status-badge"]')).toContainText(/即將進行/);
+    await expect(cards.first().locator('[data-testid="score-home"]')).toContainText('—');
+  });
+
+  // ────── AC-5: 完賽卡片可點 → 跳 /boxscore ──────
+  test('AC-5: 點擊完賽卡片 → 導向 /boxscore', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const finishedCard = page.locator('[data-testid="game-card"][data-status="finished"]').first();
+    await finishedCard.click();
+
+    await expect(page).toHaveURL(/\/boxscore/);
+  });
+
+  // ────── AC-5 [qa-v2 補充]：upcoming 卡片不可點 ──────
+  test('[qa-v2 補充] AC-5b: 即將進行場次不可點擊（cursor 非 pointer 或 click 無導航）', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+    await page.locator('[data-testid="chip-week"]', { hasText: '7' }).first().click();
+
+    const upcomingCard = page.locator('[data-testid="game-card"][data-status="upcoming"]').first();
+    const cursor = await upcomingCard.evaluate((el) => getComputedStyle(el).cursor);
+    expect(cursor).not.toBe('pointer');
+  });
+
+  // ────── AC-6: 展開工作人員 ──────
+  test('AC-6: 點卡片展開箭頭 → 顯示工作人員（裁判 / 場務 / 攝影 / 器材）', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const cardWithStaff = page.locator('[data-testid="game-card"]').first();
+    await cardWithStaff.locator('[data-testid="staff-toggle"]').click();
+
+    const staffPanel = cardWithStaff.locator('[data-testid="staff-panel"]');
+    await expect(staffPanel).toBeVisible();
+    await expect(staffPanel).toContainText(/裁判/);
+  });
+
+  // ────── AC-6 [qa-v2 補充]：再次點擊收起 ──────
+  test('[qa-v2 補充] AC-6b: 再次點擊展開箭頭 → 工作人員面板收起', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const card = page.locator('[data-testid="game-card"]').first();
+    const toggle = card.locator('[data-testid="staff-toggle"]');
+    const panel = card.locator('[data-testid="staff-panel"]');
+
+    await toggle.click();
+    await expect(panel).toBeVisible();
+
+    await toggle.click();
+    await expect(panel).toBeHidden();
+  });
+
+  // ────── AC-7: 暫停週 chip ──────
+  test('AC-7: 點擊「休」chip → 顯示暫停原因', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const suspendedChip = page.locator('[data-testid="chip-suspended"]').first();
+    await suspendedChip.click();
+
+    await expect(page.getByText(/過年連假/)).toBeVisible();
+  });
+
+  // ────── AC-14: 連續多週暫停 ──────
+  test('AC-14: 連續 3 週暫停 → chip 列出現 3 個獨立「休」chip，皆可點開', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const suspendedChips = page.locator('[data-testid="chip-suspended"]');
+    await expect(suspendedChips).toHaveCount(3);
+
+    // 第三個應該是 228 連假
+    await suspendedChips.nth(2).click();
+    await expect(page.getByText(/228/)).toBeVisible();
+  });
+
+  // ────── AC-15: 混合場次 ──────
+  test('AC-15: 同週 4 完賽 + 2 即將進行 → 各自正確渲染', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    // 切到 W6（mixed）
+    await page.locator('[data-testid="chip-week"]', { hasText: '6' }).first().click();
+
+    const finished = page.locator('[data-testid="game-card"][data-status="finished"]');
+    const upcoming = page.locator('[data-testid="game-card"][data-status="upcoming"]');
+    await expect(finished).toHaveCount(4);
+    await expect(upcoming).toHaveCount(2);
+  });
+
+  // ────── AC-10: Loading state ──────
+  test('AC-10: 資料載入中 → 看到 skeleton', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule(), { delayMs: 1500 });
+    await page.goto('/schedule');
+
+    // 進頁後立即（資料還沒回）skeleton 應出現
+    await expect(page.locator('[data-testid="skeleton-chip"]').first()).toBeVisible();
+    await expect(page.locator('[data-testid="skeleton-card"]').first()).toBeVisible();
+
+    // 資料載入後 skeleton 消失
+    await expect(page.locator('[data-testid="game-card"]').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="skeleton-card"]')).toHaveCount(0);
+  });
+
+  // ────── AC-11: Error state ──────
+  test('AC-11: GAS + JSON 都失敗 → 顯示「無法載入賽程」+ 重試按鈕', async ({ page }) => {
+    await mockScheduleAPI(page, null, { allFail: true });
+    await page.goto('/schedule');
+
+    await expect(page.getByText(/無法載入賽程/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
+  });
+
+  // ────── AC-11 互動：點重試 ──────
+  test('AC-11b: 點重試按鈕 → 重新嘗試載入', async ({ page }) => {
+    let callCount = 0;
+    await page.route(/script\.google\.com.*exec/, async (route) => {
+      callCount++;
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+    await page.route(/\/data\/schedule\.json/, async (route) => {
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+
+    await page.goto('/schedule');
+    await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
+
+    const initialCount = callCount;
+    await page.getByRole('button', { name: /重試/ }).click();
+
+    // 點重試後應該再次嘗試（call 數會增加）
+    await expect.poll(() => callCount).toBeGreaterThan(initialCount);
+  });
+
+  // ────── AC-12: Empty state ──────
+  test('AC-12: 該週無比賽 → 顯示「本週無賽程，下週見」+ 看上一週按鈕', async ({ page }) => {
+    await mockScheduleAPI(page, mockCurrentWeekMissing());
+    await page.goto('/schedule');
+
+    await expect(page.getByText(/本週無賽程/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /看上一週/ })).toBeVisible();
+  });
+
+  // ────── AC-13: 第 1 週邊界 ──────
+  test('AC-13: 賽季第 1 週 + 空資料 → 「看上一週」按鈕禁用或隱藏', async ({ page }) => {
+    await mockScheduleAPI(page, { season: 25, currentWeek: 1, allWeeks: [] });
+    await page.goto('/schedule');
+
+    const button = page.getByRole('button', { name: /看上一週/ });
+    const isHidden = (await button.count()) === 0;
+    if (!isHidden) {
+      await expect(button).toBeDisabled();
+    }
+  });
+
+  // ────── AC-7 [qa-v2 補充]：點休 chip 不應切到該週 ──────
+  test('[qa-v2 補充] AC-7b: 點擊「休」chip 不會把 Hero header 換成「休」（不切該週）', async ({ page }) => {
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const headerBefore = await page.getByRole('heading', { level: 1 }).textContent();
+    await page.locator('[data-testid="chip-suspended"]').first().click();
+    const headerAfter = await page.getByRole('heading', { level: 1 }).textContent();
+
+    expect(headerAfter).toBe(headerBefore);
+  });
+});
+
+// ────── AC-8 / AC-9: RWD ──────
+test.describe('Schedule Page RWD @schedule', () => {
+  test('AC-8 (regression-mobile): 手機寬度 → chip 緊湊版「W5」、卡片直排', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width >= 768, 'mobile project only');
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const chip = page.locator('[data-testid="chip-week"]').first();
+    const text = (await chip.textContent()) ?? '';
+    expect(text.trim()).toMatch(/^W?\d+$/); // 緊湊版
+
+    // 卡片直排：第一張和第二張的 X 座標應接近（垂直排列）
+    const cards = page.locator('[data-testid="game-card"]');
+    const box1 = await cards.nth(0).boundingBox();
+    const box2 = await cards.nth(1).boundingBox();
+    expect(Math.abs((box1?.x ?? 0) - (box2?.x ?? 0))).toBeLessThan(20);
+    expect((box2?.y ?? 0)).toBeGreaterThan(box1?.y ?? 0);
+  });
+
+  test('AC-9 (regression desktop): 桌機寬度 → chip 顯示「W5 · 2/7」、卡片並排', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 768, 'desktop project only');
+    await mockScheduleAPI(page, mockFullSchedule());
+    await page.goto('/schedule');
+
+    const activeChip = page.locator('[data-testid="chip-week"][data-active="true"]');
+    await expect(activeChip).toContainText(/2.*7/); // 含日期
+
+    // 卡片兩兩並排：前兩張卡 Y 座標相近
+    const cards = page.locator('[data-testid="game-card"]');
+    const box1 = await cards.nth(0).boundingBox();
+    const box2 = await cards.nth(1).boundingBox();
+    expect(Math.abs((box1?.y ?? 0) - (box2?.y ?? 0))).toBeLessThan(20);
+    expect((box2?.x ?? 0)).toBeGreaterThan(box1?.x ?? 0);
+  });
+});

--- a/tests/fixtures/schedule.ts
+++ b/tests/fixtures/schedule.ts
@@ -1,0 +1,195 @@
+/**
+ * Schedule fixture 工廠
+ *
+ * 提供測試專用的固定範例資料，含正常情境與邊界情境。
+ * 不會打 production Google Sheets，所有測試資料均在此手寫或從快照載入。
+ */
+
+export interface Game {
+  num: number;
+  time: string;
+  home: string;
+  away: string;
+  homeScore: number | null;
+  awayScore: number | null;
+  status: 'finished' | 'upcoming' | 'in_progress';
+  staff: Record<string, string[]>;
+}
+
+export interface GameWeek {
+  type: 'game';
+  week: number;
+  date: string;
+  phase: string;
+  venue: string;
+  matchups: Array<{
+    combo: number;
+    home: string;
+    away: string;
+    homeScore: number | null;
+    awayScore: number | null;
+    status: string;
+  }>;
+  games: Game[];
+}
+
+export interface SuspendedWeek {
+  type: 'suspended';
+  date: string;
+  venue: string;
+  reason: string;
+}
+
+export type ScheduleWeek = GameWeek | SuspendedWeek;
+
+export interface ScheduleData {
+  season: number;
+  currentWeek: number;
+  allWeeks: ScheduleWeek[];
+  weeks?: Record<string, GameWeek>;
+}
+
+/** 建立單一已完賽場次 */
+export function mockFinishedGame(home: string, away: string, homeScore: number, awayScore: number, num = 1, staff = {}): Game {
+  return {
+    num,
+    time: '',
+    home,
+    away,
+    homeScore,
+    awayScore,
+    status: 'finished',
+    staff,
+  };
+}
+
+/** 建立單一即將進行場次 */
+export function mockUpcomingGame(home: string, away: string, num = 1): Game {
+  return {
+    num,
+    time: '',
+    home,
+    away,
+    homeScore: null,
+    awayScore: null,
+    status: 'upcoming',
+    staff: {},
+  };
+}
+
+/** 建立完整一週 6 場已完賽 */
+export function mockGameWeek(week: number, date: string, opts: Partial<GameWeek> = {}): GameWeek {
+  const games: Game[] = [
+    mockFinishedGame('紅', '白', 34, 22, 1, { 裁判: ['李昊明(黑)', '李政軒(黑)'], 場務: ['林毅豐(黑)'] }),
+    mockFinishedGame('黑', '黃', 23, 22, 2),
+    mockFinishedGame('綠', '藍', 28, 20, 3),
+    mockFinishedGame('白', '黑', 21, 17, 4),
+    mockFinishedGame('紅', '藍', 20, 14, 5),
+    mockFinishedGame('黃', '綠', 22, 21, 6),
+  ];
+  return {
+    type: 'game',
+    week,
+    date,
+    phase: '例行賽',
+    venue: '三重',
+    matchups: games.map((g) => ({
+      combo: g.num,
+      home: g.home,
+      away: g.away,
+      homeScore: g.homeScore,
+      awayScore: g.awayScore,
+      status: g.status,
+    })),
+    games,
+    ...opts,
+  };
+}
+
+/** 混合場次：4/6 已完賽，2/6 即將進行 */
+export function mockMixedWeek(week: number, date: string): GameWeek {
+  const games: Game[] = [
+    mockFinishedGame('紅', '白', 34, 22, 1),
+    mockFinishedGame('黑', '黃', 23, 22, 2),
+    mockFinishedGame('綠', '藍', 28, 20, 3),
+    mockFinishedGame('白', '黑', 21, 17, 4),
+    mockUpcomingGame('紅', '藍', 5),
+    mockUpcomingGame('黃', '綠', 6),
+  ];
+  return {
+    type: 'game',
+    week,
+    date,
+    phase: '例行賽',
+    venue: '中正',
+    matchups: games.map((g) => ({
+      combo: g.num,
+      home: g.home,
+      away: g.away,
+      homeScore: g.homeScore,
+      awayScore: g.awayScore,
+      status: g.status,
+    })),
+    games,
+  };
+}
+
+/** 暫停週 */
+export function mockSuspendedWeek(date: string, reason: string, venue = '大安'): SuspendedWeek {
+  return { type: 'suspended', date, venue, reason };
+}
+
+/** 完整 schedule：包含已完賽 + 暫停 + 即將進行 */
+export function mockFullSchedule(): ScheduleData {
+  return {
+    season: 25,
+    currentWeek: 5,
+    allWeeks: [
+      mockGameWeek(1, '2026/1/10', { phase: '熱身賽', venue: '中正' }),
+      mockGameWeek(5, '2026/2/7'),
+      mockSuspendedWeek('2026/2/14', '過年連假'),
+      mockSuspendedWeek('2026/2/21', '過年連假'),
+      mockSuspendedWeek('2026/2/28', '228 連假'),
+      mockMixedWeek(6, '2026/3/7'),
+      {
+        type: 'game',
+        week: 7,
+        date: '2026/3/14',
+        phase: '例行賽',
+        venue: '中正',
+        matchups: [],
+        games: [
+          mockUpcomingGame('紅', '黑', 1),
+          mockUpcomingGame('藍', '綠', 2),
+          mockUpcomingGame('黃', '白', 3),
+          mockUpcomingGame('紅', '綠', 4),
+          mockUpcomingGame('黑', '白', 5),
+          mockUpcomingGame('藍', '黃', 6),
+        ],
+      },
+    ],
+  };
+}
+
+/** 空 schedule（資料源回空陣列）*/
+export function mockEmptySchedule(): ScheduleData {
+  return { season: 25, currentWeek: 1, allWeeks: [] };
+}
+
+/** 第 1 週情境（無前一週） */
+export function mockFirstWeekOnly(): ScheduleData {
+  return {
+    season: 25,
+    currentWeek: 1,
+    allWeeks: [mockGameWeek(1, '2026/1/10', { phase: '熱身賽' })],
+  };
+}
+
+/** 該週無資料情境（currentWeek 指向沒有資料的週數） */
+export function mockCurrentWeekMissing(): ScheduleData {
+  return {
+    season: 25,
+    currentWeek: 99,
+    allWeeks: [mockGameWeek(1, '2026/1/10'), mockGameWeek(2, '2026/1/17')],
+  };
+}

--- a/tests/helpers/mock-api.ts
+++ b/tests/helpers/mock-api.ts
@@ -1,0 +1,71 @@
+/**
+ * Playwright 測試用：攔截 GAS / fallback JSON 請求
+ *
+ * 使用方式：
+ *   await mockScheduleAPI(page, mockFullSchedule());          // 成功回應
+ *   await mockScheduleAPI(page, null, { gasFails: true });    // GAS 失敗 → fallback JSON
+ *   await mockScheduleAPI(page, null, { allFail: true });     // GAS + JSON 都失敗
+ *   await mockScheduleAPI(page, schedule, { delayMs: 2000 }); // 延遲 2 秒模擬載入
+ */
+
+import type { Page, Route } from '@playwright/test';
+import type { ScheduleData } from '../fixtures/schedule';
+
+interface MockOptions {
+  /** GAS 是否失敗（true 時會 fallback 到 JSON） */
+  gasFails?: boolean;
+  /** GAS + JSON 都失敗 */
+  allFail?: boolean;
+  /** 延遲毫秒數（模擬慢速網路） */
+  delayMs?: number;
+  /** 自訂 JSON fallback 內容（不指定就用 schedule 同一份） */
+  fallbackJson?: ScheduleData;
+}
+
+const GAS_PATTERN = /script\.google\.com\/macros\/s\/.+\/exec/;
+const JSON_PATTERN = /\/data\/schedule\.json$/;
+
+export async function mockScheduleAPI(
+  page: Page,
+  schedule: ScheduleData | null,
+  opts: MockOptions = {},
+): Promise<void> {
+  const { gasFails = false, allFail = false, delayMs = 0, fallbackJson } = opts;
+
+  // 攔截 GAS 請求
+  await page.route(GAS_PATTERN, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (allFail || gasFails) {
+      await route.fulfill({ status: 500, body: 'GAS error' });
+      return;
+    }
+    if (schedule) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(schedule),
+      });
+      return;
+    }
+    await route.fulfill({ status: 500, body: 'No data' });
+  });
+
+  // 攔截 fallback JSON 請求
+  await page.route(JSON_PATTERN, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (allFail) {
+      await route.fulfill({ status: 500, body: 'JSON fallback failed' });
+      return;
+    }
+    const data = fallbackJson ?? schedule;
+    if (data) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(data),
+      });
+      return;
+    }
+    await route.continue(); // 沒指定就放行（讀真實 public/data/schedule.json）
+  });
+}

--- a/tests/integration/api-fallback.integration.test.ts
+++ b/tests/integration/api-fallback.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration: src/lib/api.ts 三層 fallback 行為
+ *
+ * Tag: @api-fallback @schedule
+ * Coverage: 涵蓋 AC-11（GAS 失敗 → JSON fallback → 全失敗）的後端邏輯部分
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { mockFullSchedule } from '../fixtures/schedule';
+
+// 動態 mock import.meta.env 與 fetch
+const ORIG_FETCH = globalThis.fetch;
+
+describe('api.ts 三層 fallback (integration)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // 模擬有效 GAS URL
+    vi.stubEnv('PUBLIC_GAS_WEBAPP_URL', 'https://script.google.com/macros/s/test/exec');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIG_FETCH;
+    vi.unstubAllEnvs();
+  });
+
+  it('GAS 成功 → 直接回傳 GAS 資料（source: gas）', async () => {
+    const schedule = mockFullSchedule();
+    globalThis.fetch = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('script.google.com')) {
+        return new Response(JSON.stringify(schedule), { status: 200 });
+      }
+      throw new Error('should not hit JSON');
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('schedule');
+
+    expect(result.source).toBe('gas');
+    expect(result.data).toMatchObject({ season: 25, currentWeek: 5 });
+  });
+
+  it('GAS 失敗 → fallback 到靜態 JSON（source: static）', async () => {
+    const schedule = mockFullSchedule();
+    globalThis.fetch = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('script.google.com')) {
+        return new Response('GAS error', { status: 500 });
+      }
+      if (u.includes('schedule.json')) {
+        return new Response(JSON.stringify(schedule), { status: 200 });
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('schedule');
+
+    expect(result.source).toBe('static');
+    expect(result.data).toMatchObject({ season: 25 });
+  });
+
+  it('GAS throw + JSON 也 throw → source: error', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('schedule');
+
+    expect(result.source).toBe('error');
+    expect(result.data).toBeNull();
+    expect(result.error).toContain('network down');
+  });
+
+  it('GAS_URL 未設定（含預設 placeholder）→ 直接走 JSON fallback', async () => {
+    vi.stubEnv('PUBLIC_GAS_WEBAPP_URL', 'https://script.google.com/macros/s/REPLACE_WITH_DEPLOY_ID/exec');
+
+    const schedule = mockFullSchedule();
+    let gasCalled = false;
+    globalThis.fetch = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('script.google.com')) {
+        gasCalled = true;
+        return new Response('should not be called', { status: 500 });
+      }
+      if (u.includes('schedule.json')) {
+        return new Response(JSON.stringify(schedule), { status: 200 });
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('schedule');
+
+    expect(gasCalled).toBe(false);
+    expect(result.source).toBe('static');
+  });
+});

--- a/tests/unit/schedule-utils.test.ts
+++ b/tests/unit/schedule-utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCurrentWeek,
+  findPreviousWeekWithData,
+  getWinner,
+  isSuspended,
+  hasStaff,
+} from '../../src/lib/schedule-utils';
+import {
+  mockFullSchedule,
+  mockEmptySchedule,
+  mockFirstWeekOnly,
+  mockGameWeek,
+  mockSuspendedWeek,
+  mockFinishedGame,
+} from '../fixtures/schedule';
+
+describe('schedule-utils', () => {
+  // Covers: U-4 getCurrentWeek 邏輯
+  describe('getCurrentWeek', () => {
+    it('回傳 currentWeek 對應的 week 物件', () => {
+      const data = mockFullSchedule(); // currentWeek = 5
+      const week = getCurrentWeek(data);
+      expect(week).not.toBeNull();
+      expect(week?.type).toBe('game');
+      if (week?.type === 'game') expect(week.week).toBe(5);
+    });
+
+    it('currentWeek 找不到對應 week → 回傳 null', () => {
+      const data = { season: 25, currentWeek: 99, allWeeks: [mockGameWeek(1, '2026/1/10')] };
+      expect(getCurrentWeek(data)).toBeNull();
+    });
+
+    it('allWeeks 為空 → 回傳 null', () => {
+      expect(getCurrentWeek(mockEmptySchedule())).toBeNull();
+    });
+  });
+
+  // Covers: U-3 找上一個有資料週的邏輯
+  describe('findPreviousWeekWithData', () => {
+    it('從 W6 往回找，跳過 suspended → 回傳 W5', () => {
+      const data = mockFullSchedule();
+      const prev = findPreviousWeekWithData(data, 6);
+      expect(prev?.type).toBe('game');
+      if (prev?.type === 'game') expect(prev.week).toBe(5);
+    });
+
+    it('第 1 週往回找 → 回傳 null', () => {
+      const data = mockFirstWeekOnly();
+      expect(findPreviousWeekWithData(data, 1)).toBeNull();
+    });
+
+    it('完全沒有 game 週 → 回傳 null', () => {
+      const data = { season: 25, currentWeek: 1, allWeeks: [mockSuspendedWeek('2026/1/1', 'X')] };
+      expect(findPreviousWeekWithData(data, 1)).toBeNull();
+    });
+  });
+
+  // Covers: U-1 平手場次處理 + U-5 比分判斷
+  describe('getWinner', () => {
+    it('home 比分高 → home', () => {
+      const game = mockFinishedGame('紅', '白', 34, 22);
+      expect(getWinner(game)).toBe('home');
+    });
+
+    it('away 比分高 → away', () => {
+      const game = mockFinishedGame('紅', '白', 22, 34);
+      expect(getWinner(game)).toBe('away');
+    });
+
+    it('比分相同 → tie', () => {
+      const game = mockFinishedGame('紅', '白', 22, 22);
+      expect(getWinner(game)).toBe('tie');
+    });
+
+    it('未完賽（比分 null）→ none', () => {
+      const game = {
+        num: 1,
+        time: '',
+        home: '紅',
+        away: '白',
+        homeScore: null,
+        awayScore: null,
+        status: 'upcoming' as const,
+        staff: {},
+      };
+      expect(getWinner(game)).toBe('none');
+    });
+  });
+
+  // Covers: U-6 suspended week 偵測
+  describe('isSuspended', () => {
+    it('suspended week → true', () => {
+      expect(isSuspended(mockSuspendedWeek('2026/2/14', '過年'))).toBe(true);
+    });
+
+    it('game week → false', () => {
+      expect(isSuspended(mockGameWeek(1, '2026/1/10'))).toBe(false);
+    });
+  });
+
+  // Covers: U-2 無 staff 資料時 toggle 邏輯（先放這裡，Task 5 也會引用）
+  describe('hasStaff', () => {
+    it('staff 物件有任一非空陣列 → true', () => {
+      expect(hasStaff({ 裁判: ['李昊明(黑)'], 場務: [] })).toBe(true);
+    });
+
+    it('staff 物件全空 → false', () => {
+      expect(hasStaff({ 裁判: [], 場務: [] })).toBe(false);
+    });
+
+    it('staff 為空物件 → false', () => {
+      expect(hasStaff({})).toBe(false);
+    });
+  });
+});

--- a/tests/unit/staff-display.test.ts
+++ b/tests/unit/staff-display.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { hasStaff } from '../../src/lib/schedule-utils';
+import { mockFinishedGame } from '../fixtures/schedule';
+
+describe('staff display logic (U-2)', () => {
+  it('沒有 staff 資料 → toggle 不應該顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, {});
+    expect(hasStaff(game.staff)).toBe(false);
+  });
+
+  it('有 staff 資料（裁判 + 場務）→ toggle 應顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, {
+      裁判: ['李昊明(黑)'],
+      場務: ['林毅豐(黑)'],
+    });
+    expect(hasStaff(game.staff)).toBe(true);
+  });
+
+  it('staff 物件存在但所有 key 都是空陣列 → toggle 不應顯示', () => {
+    const game = mockFinishedGame('紅', '白', 34, 22, 1, {
+      裁判: [],
+      場務: [],
+    });
+    expect(hasStaff(game.staff)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/unit/**/*.{test,spec}.ts'],
+    include: [
+      'tests/unit/**/*.{test,spec}.ts',
+      'tests/integration/**/*.{test,spec}.ts',
+    ],
     environment: 'jsdom',
     globals: true,
   },


### PR DESCRIPTION
## Summary

實作 5-tab 結構的「賽程」頁（/schedule），完整覆蓋 Issue #1 的 15 條 AC。

- Astro 6 + React 19 island 架構：靜態頁面 + 互動 island
- Hero header / chip timeline (含 suspended popover) / 對戰卡（含 staff 展開）/ 三狀態（loading/error/empty）
- 三層 fallback：GAS API → public/data/schedule.json → empty 狀態
- RWD：mobile-first，桌機自動切寬版
- 23 unit/integration tests + 38 E2E across 4 projects

## Phase Coverage

- ✅ Phase 0: worktree + delivery 骨架
- ✅ Phase 1: qa-v2 plan + writing-plans (8 task plan)
- ✅ Phase 2: 全部 task 完成（含 4 個並行 component task）
- ✅ Phase 3: 整合測試 23/23 passed

## Files

新增：
- `src/types/schedule.ts`、`src/lib/schedule-utils.ts`
- `src/components/schedule/{ScheduleApp,ChipTimeline,GameCard,ScheduleHero,SkeletonState,ErrorState,EmptyState}.tsx`
- `tests/{fixtures/schedule,helpers/mock-api}.ts`
- `tests/unit/{schedule-utils,staff-display}.test.ts`
- `tests/integration/api-fallback.integration.test.ts`
- `tests/e2e/features/schedule.spec.ts`
- `docs/{delivery/issue-1*,specs/plans/issue-1_schedule-page}.md`

修改：
- `src/pages/schedule.astro`（移除 stub，掛載 ScheduleApp island）
- `src/lib/api.ts`（修 BASE_URL 串接 bug）
- `src/layouts/Layout.astro`（修 BASE_URL 串接 bug）
- `playwright.config.ts`（加 features-mobile project + 修 baseURL trailing slash）
- `astro.config.mjs`（加 @astrojs/react integration）
- `vitest.config.ts`（include integration tests）
- `package.json`（+react/react-dom/@astrojs/react）

## Test plan

- [x] Vitest unit + integration: 23 passed
- [x] Playwright E2E features (desktop): 18 passed
- [x] Playwright E2E features-mobile: 18 passed
- [x] Playwright E2E regression + regression-mobile: 4 passed
- [x] Astro build: 0 errors, 5 pages
- [ ] CI 通過後 merge to main → 觸發 GH Pages deploy
- [ ] UAT 驗收（Phase 6）：手動驗證 https://waterfat.github.io/taan-basketball-league/schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)