### PR TITLE
feat(#3): /standings 戰績榜頁面實作

### DIFF
--- a/docs/delivery/issue-3.md
+++ b/docs/delivery/issue-3.md
@@ -1,0 +1,98 @@
+# Issue #3: [L] feature: /standings 戰績榜頁面實作
+
+**分級**：L
+**Issue**: https://github.com/Waterfat/taan-basketball-league/issues/3
+**START_SECONDS**: 1777736533
+**Worktree**: feat/3-standings-page
+
+## Phase 0 — 開工
+
+- [x] 0.1 讀 Issue + 分級（[L]，spec_done ✅）
+- [x] 0.2 git-ops-v2 create-worktree（`../taan-basketball-league-issue-3` on `feat/3-standings-page`）
+- [x] 0.3 TaskCreate Phase Tasks（1-7）
+
+## Phase 1 — 規劃
+
+- [x] 1.1 plan_done 偵測（首次 Issue，計畫不存在）
+- [x] 1.2 qa-v2 plan #3 → `issue-3_qaplan.md`（17 E2E + 2 Integration（補）+ 5 Unit ⬜）
+- [x] 1.3 sp-writing-plans-v2 → `2026-05-02-issue-3-standings-page.md`（4 個 task，並行群組 A = {1,2}、B = {3}、C = {4}）
+
+**個人風格規則命中**：2 條 — style-rwd-list（Task 3）、style-skeleton-loading（Task 2 + Task 4）
+
+## Phase 2 — 執行
+
+| Task | 描述 | Commit | 狀態 |
+|------|------|--------|------|
+| Task 1 | 型別 + utils + 16 unit test | `32597cb` | ✅ |
+| Task 2 | Skeleton / Error / Empty / Hero | `8859525` | ✅ |
+| Task 3 | StandingsRow（mobile card + desktop table row）| `a8f8fde` | ✅ |
+| Task 4 | StandingsApp + standings.astro 接線 | `54507ce` | ✅ |
+
+群組執行：Group A（Task 1 ∥ Task 2，並行）→ Group B（Task 3）→ Group C（Task 4）
+完成驗證：vitest **41 passed (5 files)**、`npm run build` **5 pages OK**
+
+## Phase 3 — 整合測試
+
+**結果**：❌（test_gaps，工具疑似誤判）— 待主人決策
+
+### Retry r1（首次執行）
+
+- ✅ Vitest unit + integration: **41/41 passed**（5 test files）
+- ❌ code-review-graph `detect_changes_tool`: **test_gaps = 18**
+  - Untested 名單包含 5 個 React 元件 + 5 個 helper（HistoryDots/StreakLabel/rowAriaLabel/StandingsCard/StandingsTableRow）+ 5 個 utility（formatPct/getStreakClasses/...）+ 3 個 mock-api helper
+- 風險評分：0.45（中）
+
+### Retry r2（補 component smoke test）
+
+- 新增 `tests/unit/standings-components.test.ts`（11 cases，使用 `react-dom/server.renderToString`，不引入 RTL 依賴）
+- 修正 `vitest.config.ts`：新增 `esbuild.jsx: 'automatic'` + `.tsx` 副檔名納入 include
+- ✅ Vitest unit + integration: **52/52 passed**（6 test files），commit `ff1a492`
+- ❌ code-review-graph `detect_changes_tool`：**test_gaps 仍為 18**
+
+### 工具誤判分析（HARD-GATE 衝突點）
+
+`detect_changes_tool` 將以下函式列為 untested，但實際上**已有 16+11 個直接 unit test 覆蓋**：
+
+| 函式 | 實際覆蓋來源 | 工具判斷 |
+|------|------------|---------|
+| `formatPct` | `standings-utils.test.ts` U-1（4 cases 直接調用） | ❌ 誤判 untested |
+| `getStreakClasses` | 同上 U-2（3 cases 直接調用） | ❌ 誤判 untested |
+| `getHistoryDotColor` | 同上 U-3（3 cases 直接調用） | ❌ 誤判 untested |
+| `sortStandings` | 同上 U-4（2 cases 直接調用） | ❌ 誤判 untested |
+| `buildRosterLink` | 同上 U-5（3 cases 直接調用） | ❌ 誤判 untested |
+| 5 個 React 元件 | r2 新增 11 個 `renderToString` smoke test | ❌ 誤判 untested |
+| `mockKindAPI` 等 helper | 不是業務函式，是測試工具本身 | ❌ 不應列入 |
+
+**結論**：tree-sitter 對 TypeScript 的 import + call-edge 解析有缺陷，無法將 `import { formatPct } ... expect(formatPct(0,0))` 視為 Test → Function 邊。在此專案規模下無法靠補測解除（已證實補測 11 個元件後 test_gaps 數字未變）。
+
+### 與 Issue #1 對照
+
+Issue #1 同樣 17 個函式 / 元件混合 unit + E2E 覆蓋，當時 code-graph 未建置直接跳過。現在建置後，工具的 false positive 把 HARD-GATE 變成永久阻塞。
+
+### 待決策事項
+
+1. **Option A**：暫時降級 HARD-GATE — 在工具修復前以人工確認覆蓋（Phase 6 E2E 在 UAT 真實執行可補上行為層信心）
+2. **Option B**：放棄 code-graph，回到 Issue #1 模式（人工確認）
+3. **Option C**：等 code-graph 升級後重跑
+
+實質覆蓋（不依賴工具）：
+- 16 個 utility unit test（直接調用）
+- 11 個 component smoke test（SSR 渲染 + key testid 斷言）
+- 6 個 integration test（兩層 fallback × 兩個 kind）
+- 17 個 E2E spec（已寫，待 Phase 6 UAT 跑）
+
+**請主人決策後再進入 Phase 4。**
+
+## Phase 4 — 程式碼交付
+
+- [ ] 4.1 commit + push
+- [ ] 4.2 PR 建立
+- [ ] 4.3 merge to main
+
+## Phase 5 — 部署記錄
+
+（待執行）
+
+## Phase 6 — E2E 驗收
+
+（待執行）

--- a/docs/delivery/issue-3.md
+++ b/docs/delivery/issue-3.md
@@ -33,7 +33,9 @@
 
 ## Phase 3 — 整合測試
 
-**結果**：❌（test_gaps，工具疑似誤判）— 待主人決策
+**結果**：✅（人工 override，test_gaps=18 經驗證為工具 false positive）
+
+> **主人決策（Option A）**：code-graph `detect_changes_tool` 將已有直接 unit test 的 utility（`formatPct` 等 5 個）也列入 untested，證實是 tree-sitter call-edge 解析缺陷而非真實覆蓋缺口。實質覆蓋（16 utility unit + 11 component smoke + 6 integration + 17 E2E spec）充足，繼續 Phase 4。
 
 ### Retry r1（首次執行）
 

--- a/docs/delivery/issue-3_qaplan.md
+++ b/docs/delivery/issue-3_qaplan.md
@@ -1,0 +1,88 @@
+# Issue #3 QA Plan — /standings 戰績榜頁面
+
+**Issue**: [L] feature: /standings 戰績榜頁面實作
+**Worktree**: `../taan-basketball-league-issue-3`
+**Platforms**: Web（Astro 6 + Tailwind 4 + React island）
+**E2E 工具**：Playwright（regression + features projects）
+**Dispatch payload 摘要**：integration_tests=`@api-fallback @standings`，e2e_tests=`@standings`
+
+## 平台偵測
+- Web ✅（Astro multi-page，已有 `/schedule` page 範例可複用 island pattern）
+- TG Bot：無
+- Native App：無
+
+## Fixture Inventory
+
+| Entity | 既有檔 | 新增檔 | 4-action |
+|--------|-------|-------|---------|
+| ScheduleData | `tests/fixtures/schedule.ts` | — | 直接用（沿用 #1 補的 helper / 工廠）|
+| **StandingsData** | — | `tests/fixtures/standings.ts` | **補**（含 `mockFullStandings`、`mockEmptyStandings`、`mockZeroRecordStandings`、`mockEightTeamStandings`）|
+| Mock API helper | `tests/helpers/mock-api.ts`（單一 `mockScheduleAPI`）| 同檔加 `mockStandingsAPI` | **修改**（向後相容：`mockScheduleAPI` 簽章不變）|
+
+### Refactor Backlog
+- `mockKindAPI<T>` 私有底層已抽出，未來新增 `roster` / `boxscore` API 可直接複用，不再列為 backlog。
+
+### Deprecated scan
+- `tests/checklists/e2e.md` 不存在（已廢棄目錄；本 Issue 無遷移需求）。
+- `tests/e2e/issues/` 不存在。
+
+## AC 行為抽取
+
+| Coverage ID | B-ID | 行為 | 層 | 狀態 | 位置 |
+|------------|------|------|-----|------|------|
+| E-1 | B-1 | Hero header 顯示「STANDINGS」+「例行賽」+「第 25 季 · 第 5 週」+ 6 隊 | e2e | ❌→已補寫 | `tests/e2e/features/standings.spec.ts` `AC-1` |
+| E-2 | B-2 | 每列含 7 欄位（rank/dot+name/wins/losses/pct/history×6/streak） | e2e | ❌→已補寫 | `standings.spec.ts` `AC-2` |
+| E-3 | B-3 | 連勝隊伍 streak → `data-streak-type=win` + ↑ icon | e2e | ❌→已補寫 | `standings.spec.ts` `AC-3` |
+| E-4 | B-4 | 連敗隊伍 streak → `data-streak-type=lose` + ↓ icon | e2e | ❌→已補寫 | `standings.spec.ts` `AC-4` |
+| E-5 | B-5 | history 圓點：W → 隊伍主色、L → 灰色（`data-result` 屬性） | e2e | ❌→已補寫 | `standings.spec.ts` `AC-5` |
+| E-6 | B-6 | 點擊隊伍列 → 導向 `/roster?team=<id>` | e2e | ❌→已補寫 | `standings.spec.ts` `AC-6` |
+| E-7 | B-7 | rank 順序 = 後台給的順序（前端不重排） | e2e | ❌→已補寫 | `standings.spec.ts` `AC-7` |
+| E-8 | B-8 | RWD mobile：6 張卡片垂直堆疊 | e2e | ❌→已補寫 | `standings.spec.ts` `AC-8 (regression-mobile)` |
+| E-9 | B-9 | RWD desktop：橫排表格 6 列 | e2e | ❌→已補寫 | `standings.spec.ts` `AC-9 (regression desktop)` |
+| E-10 | B-10 | Loading → skeleton（hero 灰塊 + 6 列灰塊） | e2e | ❌→已補寫 | `standings.spec.ts` `AC-10` |
+| E-11 | B-11 | Error → 「無法載入戰績」+ 重試按鈕 | e2e | ❌→已補寫 | `standings.spec.ts` `AC-11` |
+| E-12 | B-12 | [qa-v2 補充] 點重試按鈕 → 重新發 fetch | e2e | ❌→已補寫 | `standings.spec.ts` `AC-11b` |
+| E-13 | B-13 | Empty（teams=[]）→ 「賽季尚未開始」+ 看球員按鈕 | e2e | ❌→已補寫 | `standings.spec.ts` `AC-12` |
+| E-14 | B-14 | [qa-v2 補充] 點「看球員名單」→ /roster | e2e | ❌→已補寫 | `standings.spec.ts` `AC-12b` |
+| E-15 | B-15 | 0勝 0敗 → pct 顯示「—」、不顯示 0.0% | e2e | ❌→已補寫 | `standings.spec.ts` `AC-13` |
+| E-16 | B-16 | 8 隊資料 → 不爆版（無水平 overflow） | e2e | ❌→已補寫 | `standings.spec.ts` `AC-14` |
+| I-1 | B-fetch | `fetchData('standings')` GAS 失敗 → 走 `/data/standings.json` | integration | ❌→已補寫 | `tests/integration/api-fallback.integration.test.ts`（新增 standings case） |
+| I-2 | B-fetch | `fetchData('standings')` GAS+JSON 都失敗 → `source: error` | integration | ❌→已補寫 | 同上 |
+| I-3 | B-fetch | `fetchData('schedule')` 既有覆蓋（4 cases） | integration | ✅ 既有 | 同檔 |
+| U-1 | B-pct | `formatPct(wins, losses)`：0/0 → '—'、否則回傳 `xx.x%` | unit | ⬜ Phase 2 | `tests/unit/standings-utils.test.ts` |
+| U-2 | B-streak | `getStreakClasses(streakType)`：win → orange + up、lose → red + down、none → 預設 | unit | ⬜ Phase 2 | 同上 |
+| U-3 | B-history | `getHistoryDotColor(result, teamId)`：W → 隊伍主色、L → 灰 | unit | ⬜ Phase 2 | 同上 |
+| U-4 | B-rank | `sortStandings(teams)` 不重排（identity）— 防止意外排序 | unit | ⬜ Phase 2 | 同上 |
+| U-5 | B-roster-link | `buildRosterLink(team)` → `/roster?team=<TeamColorId>` | unit | ⬜ Phase 2 | 同上 |
+
+> 說明：sp-writing-plans-v2 從此表讀取所有 U-/I-/E-* ID。Phase 3 讀 I-* 行；Phase 6 讀 E-* 行；Task 設計讀 U-* 行（✅ 跳過、⬜ 建立）。
+
+## Phase 3 執行清單（Integration + Unit）
+
+```bash
+npx vitest run
+```
+
+涵蓋：
+- ✅ 既有 `tests/integration/api-fallback.integration.test.ts`（4 cases）
+- 新補 standings 2 cases（同檔末段）
+- ✅ 既有 unit：`schedule-utils.test.ts`、`staff-display.test.ts`、`sample.test.ts`
+- ⬜ Phase 2 task 補：`tests/unit/standings-utils.test.ts`（U-1 ~ U-5）
+
+Phase 3 通過條件：
+- 所有 unit + integration test 通過
+- code-review-graph `detect_changes_tool` test_gaps = 0（或記錄缺口已被間接覆蓋）
+
+## Phase 6 執行清單（E2E）
+
+```bash
+npx playwright test tests/e2e/regression
+npx playwright test tests/e2e/features/standings.spec.ts
+```
+
+涵蓋：
+- 新補 `tests/e2e/features/standings.spec.ts`（17 個 test，含 RWD describe 2 個 — 含 mobile/desktop project skip）
+- 既有 `tests/e2e/regression/schedule.regression.spec.ts`（5-tab nav 中應仍可導到 /standings）
+- ⬜ 視結果決定是否補一支 `tests/e2e/regression/standings.regression.spec.ts`（純 smoke：頁面載入、6 列可見）
+
+Phase 6 通過條件：UAT URL E2E 全部通過、無 console error。

--- a/docs/delivery/issue-3_task-1.md
+++ b/docs/delivery/issue-3_task-1.md
@@ -1,0 +1,20 @@
+# Issue #3 Task 1: 型別 + utils + unit tests (U-1 ~ U-5)
+
+**Plan**: `docs/specs/plans/2026-05-02-issue-3-standings-page.md`（Task 1 section）
+**Worktree**: `/Users/waterfat/Documents/taan-basketball-league-issue-3`
+**並行群組**：Group A（與 Task 2 平行）
+
+## Files
+- Create: `src/types/standings.ts`
+- Create: `src/lib/standings-utils.ts`
+- Create: `tests/unit/standings-utils.test.ts`
+
+## Style Rules
+無命中
+
+## Status
+- [ ] Step 1：寫失敗測試
+- [ ] Step 2：確認 vitest FAIL
+- [ ] Step 3：實作 types + utils
+- [ ] Step 4：vitest 16 cases PASS
+- [ ] Step 5：commit

--- a/docs/delivery/issue-3_task-2.md
+++ b/docs/delivery/issue-3_task-2.md
@@ -1,0 +1,21 @@
+# Issue #3 Task 2: 狀態元件 (Skeleton / Error / Empty / Hero)
+
+**Plan**: `docs/specs/plans/2026-05-02-issue-3-standings-page.md`（Task 2 section）
+**Worktree**: `/Users/waterfat/Documents/taan-basketball-league-issue-3`
+**並行群組**：Group A（與 Task 1 平行）
+
+## Files
+- Create: `src/components/standings/SkeletonState.tsx`
+- Create: `src/components/standings/ErrorState.tsx`
+- Create: `src/components/standings/EmptyState.tsx`
+- Create: `src/components/standings/StandingsHero.tsx`
+
+## Style Rules
+- style-skeleton-loading（命中：本 task 建立 SkeletonState）
+
+## Status
+- [ ] Step 1：跳過 unit test（視覺由 E2E 涵蓋）
+- [ ] Step 2：確認元件不存在
+- [ ] Step 3：實作 4 個元件
+- [ ] Step 4：vitest run 既有 25 cases 不破壞
+- [ ] Step 5：commit

--- a/docs/delivery/issue-3_task-3.md
+++ b/docs/delivery/issue-3_task-3.md
@@ -1,0 +1,19 @@
+# Issue #3 Task 3: StandingsRow (mobile card + desktop table row)
+
+**Plan**: `docs/specs/plans/2026-05-02-issue-3-standings-page.md`（Task 3 section）
+**Worktree**: `/Users/waterfat/Documents/taan-basketball-league-issue-3`
+**並行群組**：Group B（單行，等 Group A 完成）
+**相依**：Task 1（types + utils）
+
+## Files
+- Create: `src/components/standings/StandingsRow.tsx`
+
+## Style Rules
+- style-rwd-list（命中：本 task 建立 7 欄位 RWD 列表元件）
+
+## Status
+- [ ] Step 1：跳過 unit test（視覺由 E2E 涵蓋）
+- [ ] Step 2：確認元件不存在
+- [ ] Step 3：實作 StandingsCard + StandingsTableRow
+- [ ] Step 4：vitest run 既有 41 cases 不破壞
+- [ ] Step 5：commit

--- a/docs/delivery/issue-3_task-4.md
+++ b/docs/delivery/issue-3_task-4.md
@@ -1,0 +1,20 @@
+# Issue #3 Task 4: StandingsApp + standings.astro 接線
+
+**Plan**: `docs/specs/plans/2026-05-02-issue-3-standings-page.md`（Task 4 section）
+**Worktree**: `/Users/waterfat/Documents/taan-basketball-league-issue-3`
+**並行群組**：Group C（單行，等 Group A + Group B 完成）
+**相依**：Task 1 + Task 2 + Task 3
+
+## Files
+- Create: `src/components/standings/StandingsApp.tsx`
+- Modify: `src/pages/standings.astro`
+
+## Style Rules
+- style-skeleton-loading（命中：本 task 建立 fetch + state machine 主島，控制 loading 顯示時機）
+
+## Status
+- [ ] Step 1：跳過 unit test（行為由 E2E 涵蓋）
+- [ ] Step 2：確認 page 仍是佔位
+- [ ] Step 3：實作 StandingsApp + 改寫 standings.astro
+- [ ] Step 4：vitest 41 + npm run build 通過
+- [ ] Step 5：commit

--- a/docs/specs/plans/2026-05-02-issue-3-standings-page.md
+++ b/docs/specs/plans/2026-05-02-issue-3-standings-page.md
@@ -1,0 +1,794 @@
+# /standings 戰績榜頁面 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `/standings` 從佔位頁升級為功能完整的戰績榜頁，含 6 隊排行、勝率、history 圓點、連勝/連敗 streak、三狀態（loading / error / empty）與 RWD（mobile 卡片堆疊、desktop 橫排表格），點擊隊伍導向 `/roster?team=<id>`。
+
+**Architecture:** Astro page 內嵌 React island（沿用 Issue #1 ScheduleApp 的 state-machine pattern：`'loading' | 'error' | 'empty' | 'ok'`），三層資料 fallback 透過既有 `src/lib/api.ts` 的 `fetchData('standings')`。RWD 採 Tailwind utility 切換（`md:hidden` / `hidden md:table`），不重複渲染兩份 DOM。隊伍配色全部讀 `TEAM_CONFIG` 動態注入，不寫 inline style。
+
+**Tech Stack:** Astro 6 multi-page、React 19 island、Tailwind CSS 4 `@theme` tokens、TypeScript strict、Vitest（unit）、Playwright（E2E features + regression）。
+
+**個人風格規則**：命中 2 條 — style-rwd-list, style-skeleton-loading
+
+**Code Graph**：圖未建立，跳過
+
+---
+
+## Coverage Matrix
+
+| qaplan ID | 描述 | 對應 Task | 覆蓋方式 |
+|-----------|------|-----------|---------|
+| U-1 | `formatPct(wins, losses)`：0/0 → '—'、否則 `xx.x%` | Task 1 Step 1 | unit test (`tests/unit/standings-utils.test.ts`) |
+| U-2 | `getStreakClasses(streakType)`：win/lose/none 對應顏色 + 箭頭 class | Task 1 Step 1 | unit test |
+| U-3 | `getHistoryDotColor(result, teamId)`：W → 隊伍主色、L → 灰 | Task 1 Step 1 | unit test |
+| U-4 | `sortStandings(teams)` 不重排（identity） | Task 1 Step 1 | unit test |
+| U-5 | `buildRosterLink(team)` → `/roster?team=<TeamColorId>` | Task 1 Step 1 | unit test |
+| I-1 | `fetchData('standings')` GAS 失敗 → 走 `/data/standings.json` | （已存在 by qa-v2 補寫） | `tests/integration/api-fallback.integration.test.ts` (新增 standings cases) |
+| I-2 | `fetchData('standings')` GAS+JSON 都失敗 → `source: error` | （已存在 by qa-v2 補寫） | 同上 |
+| E-1 ~ E-16 | 17 個 E2E case（AC-1~14 + 2 個 [qa-v2 補充]） | （已存在 by qa-v2 補寫） | `tests/e2e/features/standings.spec.ts` |
+
+> 說明：所有 E-* / I-* 的 spec 已由 qa-v2 在 Phase 1.2 補寫；本計畫的 task 只負責讓 ⬜ unit test 通過 + 讓 E2E spec 通過（即實作頁面）。
+
+---
+
+## 檔案結構規劃
+
+| Path | Action | 職責 |
+|------|--------|------|
+| `src/types/standings.ts` | Create | 型別：`StreakType` / `HistoryResult` / `TeamStanding` / `StandingsData` |
+| `src/lib/standings-utils.ts` | Create | 純函式：`formatPct` / `getStreakClasses` / `getHistoryDotColor` / `sortStandings` / `buildRosterLink` |
+| `src/components/standings/SkeletonState.tsx` | Create | Loading 骨架（Hero + 6 列） |
+| `src/components/standings/ErrorState.tsx` | Create | 「無法載入戰績」+ 重試按鈕 |
+| `src/components/standings/EmptyState.tsx` | Create | 「賽季尚未開始 ⛹️」+ 「看球員名單」連結 |
+| `src/components/standings/StandingsHero.tsx` | Create | Hero 標題 + 副標 |
+| `src/components/standings/StandingsRow.tsx` | Create | 單列（mobile card + desktop table row 雙模式） |
+| `src/components/standings/StandingsApp.tsx` | Create | React island，state machine + fetch + 渲染 |
+| `src/pages/standings.astro` | Modify | 從佔位頁改為 `<StandingsApp client:load baseUrl={baseUrl} />` |
+| `tests/unit/standings-utils.test.ts` | Create | U-1 ~ U-5（共 5 組 describe） |
+
+---
+
+## 並行與相依
+
+```
+Group A（並行）：Task 1 ∥ Task 2
+Group B（單行，等 A）：Task 3（depends on Task 1 utils）
+Group C（單行，等 A+B）：Task 4（depends on Task 1, 2, 3）
+```
+
+---
+
+### Task 1：型別 + utils + unit tests（U-1 ~ U-5）
+
+**Files:**
+- Create: `src/types/standings.ts`
+- Create: `src/lib/standings-utils.ts`
+- Test: `tests/unit/standings-utils.test.ts`
+
+## Style Rules（subagent 必讀，由 Step 0.5 注入）
+
+> 此 task 僅涉及 types + utils + unit test，無 UI、無 fetch。trigger 不命中 → 無命中。
+
+**無命中**
+
+- [ ] **Step 1：寫失敗測試（TDD）**
+
+```typescript
+// tests/unit/standings-utils.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  formatPct,
+  getStreakClasses,
+  getHistoryDotColor,
+  sortStandings,
+  buildRosterLink,
+} from '../../src/lib/standings-utils';
+import { mockFullStandings, mockZeroRecordStandings } from '../fixtures/standings';
+
+describe('standings-utils', () => {
+  // Covers: U-1 formatPct
+  describe('formatPct', () => {
+    it('0勝 0敗 → 回傳 "—"（避免誤導為 0.0%）', () => {
+      expect(formatPct(0, 0)).toBe('—');
+    });
+
+    it('4勝 2敗 → 回傳 "66.7%"', () => {
+      expect(formatPct(4, 2)).toBe('66.7%');
+    });
+
+    it('1勝 5敗 → 回傳 "16.7%"', () => {
+      expect(formatPct(1, 5)).toBe('16.7%');
+    });
+
+    it('3勝 3敗 → 回傳 "50.0%"', () => {
+      expect(formatPct(3, 3)).toBe('50.0%');
+    });
+  });
+
+  // Covers: U-2 getStreakClasses
+  describe('getStreakClasses', () => {
+    it('win → 含 orange 文字色 + ↑ 箭頭', () => {
+      const result = getStreakClasses('win');
+      expect(result.colorClass).toMatch(/orange/);
+      expect(result.arrow).toBe('↑');
+    });
+
+    it('lose → 含 紅色文字色 + ↓ 箭頭', () => {
+      const result = getStreakClasses('lose');
+      expect(result.colorClass).toMatch(/red/);
+      expect(result.arrow).toBe('↓');
+    });
+
+    it('none → 預設灰色、無箭頭', () => {
+      const result = getStreakClasses('none');
+      expect(result.colorClass).toMatch(/gray|txt-mid/);
+      expect(result.arrow).toBe('');
+    });
+  });
+
+  // Covers: U-3 getHistoryDotColor
+  describe('getHistoryDotColor', () => {
+    it('W + 綠 → 回傳隊伍綠色 hex', () => {
+      // 綠隊主色 #2e7d32（src/config/teams.ts）
+      expect(getHistoryDotColor('W', '綠')).toBe('#2e7d32');
+    });
+
+    it('L + 任何隊 → 回傳灰色（不是隊伍主色）', () => {
+      const grey = getHistoryDotColor('L', '綠');
+      expect(grey).not.toBe('#2e7d32');
+      expect(grey.toLowerCase()).toMatch(/^#[9ab][9ab][9ab]/i); // 灰系 hex（如 #9e9e9e / #aaa）
+    });
+
+    it('未知隊伍 → fallback 到灰（不 throw）', () => {
+      expect(() => getHistoryDotColor('W', '紫')).not.toThrow();
+    });
+  });
+
+  // Covers: U-4 sortStandings（identity，前端不重排）
+  describe('sortStandings', () => {
+    it('回傳順序與輸入完全一致（rank 由後台決定）', () => {
+      const data = mockFullStandings();
+      const sorted = sortStandings(data.teams);
+      expect(sorted.map((t) => t.team)).toEqual(data.teams.map((t) => t.team));
+    });
+
+    it('勝率相同 rank 不同 → 仍照 rank 順序（不重排）', () => {
+      const data = mockFullStandings(); // rank 3,4,5 都是 50.0%
+      const sorted = sortStandings(data.teams);
+      const ties = sorted.filter((t) => t.pct === '50.0%').map((t) => t.team);
+      expect(ties).toEqual(['黑', '黃', '白']);
+    });
+  });
+
+  // Covers: U-5 buildRosterLink
+  describe('buildRosterLink', () => {
+    it('綠隊 → /roster?team=green', () => {
+      expect(buildRosterLink('綠')).toBe('/roster?team=green');
+    });
+
+    it('紅隊 → /roster?team=red', () => {
+      expect(buildRosterLink('紅')).toBe('/roster?team=red');
+    });
+
+    it('未知隊伍 → fallback 到 /roster（無 query）', () => {
+      expect(buildRosterLink('紫')).toBe('/roster');
+    });
+  });
+
+  // Covers: U-1 邊界（zero-record 整體一致性）
+  it('mockZeroRecordStandings 的所有隊 pct 都應為 "—"', () => {
+    const data = mockZeroRecordStandings();
+    data.teams.forEach((t) => {
+      expect(formatPct(t.wins, t.losses)).toBe('—');
+    });
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+npx vitest run tests/unit/standings-utils.test.ts
+```
+預期：FAIL — `Cannot find module '../../src/lib/standings-utils'`
+
+- [ ] **Step 3：實作最小程式碼**
+
+```typescript
+// src/types/standings.ts
+export type StreakType = 'win' | 'lose' | 'none';
+export type HistoryResult = 'W' | 'L';
+
+export interface TeamStanding {
+  rank: number;
+  name: string;     // 「綠隊」
+  team: string;     // 「綠」（對應 TEAM_CONFIG key）
+  wins: number;
+  losses: number;
+  pct: string;
+  history: HistoryResult[];
+  streak: string;
+  streakType: StreakType;
+}
+
+export interface StandingsData {
+  season: number;
+  phase: string;
+  currentWeek: number;
+  teams: TeamStanding[];
+  matrix?: unknown;
+}
+```
+
+```typescript
+// src/lib/standings-utils.ts
+import type { HistoryResult, StreakType, TeamStanding } from '../types/standings';
+import { TEAM_CONFIG } from '../config/teams';
+
+const GREY = '#9e9e9e';
+
+export function formatPct(wins: number, losses: number): string {
+  const total = wins + losses;
+  if (total === 0) return '—';
+  return `${((wins / total) * 100).toFixed(1)}%`;
+}
+
+export interface StreakStyle {
+  colorClass: string;
+  arrow: '↑' | '↓' | '';
+}
+
+export function getStreakClasses(type: StreakType): StreakStyle {
+  if (type === 'win') return { colorClass: 'text-orange', arrow: '↑' };
+  if (type === 'lose') return { colorClass: 'text-red-600', arrow: '↓' };
+  return { colorClass: 'text-txt-mid', arrow: '' };
+}
+
+export function getHistoryDotColor(result: HistoryResult, teamId: string): string {
+  if (result === 'L') return GREY;
+  const team = TEAM_CONFIG[teamId];
+  return team?.color ?? GREY;
+}
+
+/** 不重排，identity — 防止未來誤加排序 */
+export function sortStandings(teams: TeamStanding[]): TeamStanding[] {
+  return [...teams];
+}
+
+export function buildRosterLink(teamId: string): string {
+  const team = TEAM_CONFIG[teamId];
+  if (!team) return '/roster';
+  return `/roster?team=${team.id}`;
+}
+```
+
+- [ ] **Step 4：確認測試通過**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+npx vitest run tests/unit/standings-utils.test.ts
+```
+預期：PASS — `Tests  16 passed (16)`（formatPct 4 + getStreakClasses 3 + getHistoryDotColor 3 + sortStandings 2 + buildRosterLink 3 + zero-record 1 = 16）
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/types/standings.ts src/lib/standings-utils.ts tests/unit/standings-utils.test.ts
+git commit -m "feat(standings): add types and utils for standings page (#3)"
+```
+
+---
+
+### Task 2：狀態元件（Skeleton / Error / Empty / Hero）
+
+**Files:**
+- Create: `src/components/standings/SkeletonState.tsx`
+- Create: `src/components/standings/ErrorState.tsx`
+- Create: `src/components/standings/EmptyState.tsx`
+- Create: `src/components/standings/StandingsHero.tsx`
+
+## Style Rules（subagent 必讀，由 Step 0.5 注入）
+
+### style-skeleton-loading（命中：本 task 建立 SkeletonState 元件，是非同步資料載入的骨架）
+
+**核心原則**：操作立刻有視覺回饋，等待期不留白。
+
+**禁止**：
+- ❌ 整頁 spinner
+- ❌ 頁面空白等資料
+- ❌ `mounted` 動畫 pattern
+
+**Skeleton 設計原則**：
+1. 形狀對應真實內容（卡片用卡片形狀、標題用長條，**不用** spinner）
+2. padding/spacing 與真實頁面一致（避免 layout shift）
+3. 動態用 `animate-pulse`
+4. 色塊本身就是語言，不需要「讀取中…」文字
+
+- [ ] **Step 1：寫失敗測試（TDD）**
+
+> 本 task 元件為純展示，視覺與互動行為已在 `tests/e2e/features/standings.spec.ts`（Phase 6 跑）涵蓋（AC-10 / AC-11 / AC-11b / AC-12 / AC-12b）。**不重複寫 unit test**。Step 1 改為「寫一支型別冒煙測試」確保元件 export 與 props 介面正確。
+
+```typescript
+// tests/unit/standings-components.test.tsx 不建立。
+// 改用：執行 `npm run build` 驗證 TS 通過 + 元件可被 import。
+```
+
+跳過 Step 1（無新 unit test，視覺/互動由 E2E 覆蓋）。
+
+- [ ] **Step 2：確認 build 失敗（元件尚未存在）**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+# 若 Task 4 的 StandingsApp.tsx 已 import 這些元件 → build 會失敗
+# 此 Task 獨立執行時可改用：grep 確認檔案不存在
+ls src/components/standings/SkeletonState.tsx 2>/dev/null
+```
+預期：no such file（檔案不存在）
+
+- [ ] **Step 3：實作最小程式碼**
+
+```tsx
+// src/components/standings/SkeletonState.tsx
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse">
+      {/* Hero skeleton */}
+      <div data-testid="skeleton-hero" className="text-center mb-6">
+        <div className="h-10 w-40 bg-gray-200 rounded mx-auto mb-3" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+
+      {/* 6 列灰塊 — mobile 每張卡 / desktop 每列 */}
+      <div className="space-y-3 md:space-y-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            data-testid="skeleton-row"
+            className="h-16 md:h-12 bg-gray-200 rounded-2xl md:rounded"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+```tsx
+// src/components/standings/ErrorState.tsx
+interface Props {
+  onRetry: () => void;
+  message?: string;
+}
+
+export function ErrorState({ onRetry, message = '無法載入戰績' }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">{message}</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}
+```
+
+```tsx
+// src/components/standings/EmptyState.tsx
+interface Props {
+  baseUrl: string;
+  message?: string;
+}
+
+export function EmptyState({ baseUrl, message = '賽季尚未開始 ⛹️' }: Props) {
+  const rosterHref = `${baseUrl.replace(/\/$/, '')}/roster`;
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <p className="text-lg text-txt-dark mb-6">{message}</p>
+      <a
+        href={rosterHref}
+        className="inline-block px-6 py-2 bg-navy text-white rounded-lg font-bold hover:bg-navy-2 transition"
+      >
+        看球員名單
+      </a>
+    </div>
+  );
+}
+```
+
+```tsx
+// src/components/standings/StandingsHero.tsx
+interface Props {
+  season: number;
+  phase: string;
+  currentWeek: number;
+}
+
+export function StandingsHero({ season, phase, currentWeek }: Props) {
+  return (
+    <header className="text-center px-4 py-6 md:py-10">
+      <h1 className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        STANDINGS · {phase}
+      </h1>
+      <div className="font-condensed text-base md:text-lg text-txt-mid">
+        第 {season} 季 · 第 {currentWeek} 週
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 4：確認元件可被 build**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+# 確認檔案均建立
+ls src/components/standings/{SkeletonState,ErrorState,EmptyState,StandingsHero}.tsx
+# 跑既有 unit/integration 確保沒打壞
+npx vitest run
+```
+預期：4 個檔案存在 + 既有 25 個 vitest case 全部通過
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/standings/
+git commit -m "feat(standings): add skeleton/error/empty/hero components (#3)"
+```
+
+---
+
+### Task 3：StandingsRow（mobile card + desktop table row）
+
+**Files:**
+- Create: `src/components/standings/StandingsRow.tsx`
+
+**相依：** Task 1（types + utils）必須先完成
+
+## Style Rules（subagent 必讀，由 Step 0.5 注入）
+
+### style-rwd-list（命中：本 task 建立 7 欄位列表元件）
+
+**PC（md breakpoint 以上）**
+- 使用標準橫排 table 展開所有欄位
+
+**Mobile（sm breakpoint 以下）**
+- 改為 card 呈現，每筆資料一張卡片
+- 卡片標題：主要識別欄位（隊伍名 + rank）
+- 卡片內容：次要欄位以 label + value 列出（W/L、勝率、history、streak）
+
+**實作策略**：在 `StandingsApp.tsx` 用 `hidden md:table` 顯示桌機 table、用 `md:hidden space-y-3` 顯示 mobile card 列表；本 task 的 `StandingsRow` 提供 `<TableRow>` 與 `<MobileCard>` 兩個 sub-component（同檔 export）。
+
+- [ ] **Step 1：寫失敗測試（TDD）**
+
+> 本元件的視覺與資料屬性（`data-testid`、`data-result`、`data-streak-type`）已在 `tests/e2e/features/standings.spec.ts` 涵蓋（AC-2 / AC-3 / AC-4 / AC-5 / AC-6）。**不重複寫 unit test**。
+
+跳過 Step 1（視覺/互動由 E2E 覆蓋；utils 行為在 Task 1 已測）。
+
+- [ ] **Step 2：確認元件不存在**
+
+```bash
+ls /Users/waterfat/Documents/taan-basketball-league-issue-3/src/components/standings/StandingsRow.tsx 2>/dev/null
+```
+預期：no such file
+
+- [ ] **Step 3：實作最小程式碼**
+
+```tsx
+// src/components/standings/StandingsRow.tsx
+import type { TeamStanding } from '../../types/standings';
+import {
+  buildRosterLink,
+  getHistoryDotColor,
+  getStreakClasses,
+} from '../../lib/standings-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  team: TeamStanding;
+  baseUrl: string;
+}
+
+function HistoryDots({ team, history }: { team: string; history: TeamStanding['history'] }) {
+  return (
+    <div data-testid="history" className="flex gap-1">
+      {history.map((r, i) => (
+        <span
+          key={i}
+          data-testid="history-dot"
+          data-result={r}
+          className="w-2.5 h-2.5 rounded-full inline-block"
+          style={{ backgroundColor: getHistoryDotColor(r, team) }}
+          aria-label={r === 'W' ? '勝' : '敗'}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StreakLabel({ team }: { team: TeamStanding }) {
+  const { colorClass, arrow } = getStreakClasses(team.streakType);
+  return (
+    <span
+      data-testid="streak"
+      data-streak-type={team.streakType}
+      className={`font-condensed text-sm ${colorClass}`}
+    >
+      {team.streak}
+      {arrow && <span aria-hidden="true"> {arrow}</span>}
+    </span>
+  );
+}
+
+function rowAriaLabel(t: TeamStanding) {
+  return `${t.name} 第 ${t.rank} 名 ${t.wins} 勝 ${t.losses} 敗`;
+}
+
+/** Mobile card 模式 */
+export function StandingsCard({ team, baseUrl }: Props) {
+  const config = TEAM_CONFIG[team.team];
+  const href = `${baseUrl.replace(/\/$/, '')}${buildRosterLink(team.team)}`;
+  return (
+    <a
+      href={href}
+      data-testid="standings-row"
+      aria-label={rowAriaLabel(team)}
+      className="block bg-white border border-warm-2 rounded-2xl p-4 hover:border-orange transition"
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <span data-testid="rank" className="font-display text-2xl text-txt-dark w-8">
+          {team.rank}
+        </span>
+        <span
+          data-testid="team-dot"
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: config?.color ?? '#999' }}
+        />
+        <span data-testid="team-name" className="font-bold text-lg">
+          {team.team}
+        </span>
+        <span className="ml-auto"><StreakLabel team={team} /></span>
+      </div>
+      <div className="flex items-center gap-4 text-sm text-txt-mid">
+        <span><span data-testid="wins" className="font-bold text-txt-dark">{team.wins}</span> 勝</span>
+        <span><span data-testid="losses" className="font-bold text-txt-dark">{team.losses}</span> 敗</span>
+        <span data-testid="pct" className="font-condensed">{team.pct}</span>
+        <span className="ml-auto"><HistoryDots team={team.team} history={team.history} /></span>
+      </div>
+    </a>
+  );
+}
+
+/** Desktop table row 模式 */
+export function StandingsTableRow({ team, baseUrl }: Props) {
+  const config = TEAM_CONFIG[team.team];
+  const href = `${baseUrl.replace(/\/$/, '')}${buildRosterLink(team.team)}`;
+  return (
+    <tr
+      data-testid="standings-row"
+      onClick={() => { window.location.href = href; }}
+      role="link"
+      aria-label={rowAriaLabel(team)}
+      className="cursor-pointer hover:bg-warm-1 transition border-b border-warm-2"
+    >
+      <td data-testid="rank" className="font-display text-2xl px-4 py-3">{team.rank}</td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span
+            data-testid="team-dot"
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: config?.color ?? '#999' }}
+          />
+          <span data-testid="team-name" className="font-bold">{team.team}</span>
+        </div>
+      </td>
+      <td data-testid="wins" className="px-4 py-3 font-condensed">{team.wins}</td>
+      <td data-testid="losses" className="px-4 py-3 font-condensed">{team.losses}</td>
+      <td data-testid="pct" className="px-4 py-3 font-condensed">{team.pct}</td>
+      <td className="px-4 py-3"><HistoryDots team={team.team} history={team.history} /></td>
+      <td className="px-4 py-3"><StreakLabel team={team} /></td>
+    </tr>
+  );
+}
+```
+
+- [ ] **Step 4：確認檔案存在 + tsc / vitest 不破壞**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+ls src/components/standings/StandingsRow.tsx
+npx vitest run
+```
+預期：檔案存在；既有 vitest 全部通過（已含 16 個新 unit test，total 41 cases）
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/standings/StandingsRow.tsx
+git commit -m "feat(standings): add row component (mobile card + desktop table row) (#3)"
+```
+
+---
+
+### Task 4：StandingsApp + standings.astro 接線
+
+**Files:**
+- Create: `src/components/standings/StandingsApp.tsx`
+- Modify: `src/pages/standings.astro`
+
+**相依：** Task 1, 2, 3 都必須先完成
+
+## Style Rules（subagent 必讀，由 Step 0.5 注入）
+
+### style-skeleton-loading（命中：本 task 建立 fetch + state machine 主島，控制 loading 顯示時機）
+
+不重複貼規則內文（見 Task 2 已注入）。**重點重申**：
+- StandingsApp 在 `'loading'` state 必須直接 return `<SkeletonState />`，不寫成「先空白再顯示」。
+- 不允許在 island 內寫整頁 spinner。
+
+- [ ] **Step 1：寫失敗測試（TDD）**
+
+> 本 task 整合行為（state-machine 三狀態切換、retry、roster 連結）已在 `tests/e2e/features/standings.spec.ts` 全部覆蓋（AC-1, AC-6, AC-10, AC-11, AC-11b, AC-12, AC-12b）。**不重複寫 unit test**（避免測試 React state 內部，違反「測行為而非實作」）。
+
+跳過 Step 1。
+
+- [ ] **Step 2：確認 page 仍是佔位**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+grep -q "規劃中" src/pages/standings.astro && echo "still placeholder"
+```
+預期：`still placeholder`
+
+- [ ] **Step 3：實作最小程式碼**
+
+```tsx
+// src/components/standings/StandingsApp.tsx
+import { useEffect, useState, useCallback } from 'react';
+import type { StandingsData } from '../../types/standings';
+import { fetchData } from '../../lib/api';
+import { sortStandings } from '../../lib/standings-utils';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { StandingsHero } from './StandingsHero';
+import { StandingsCard, StandingsTableRow } from './StandingsRow';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function StandingsApp({ baseUrl }: Props) {
+  const [data, setData] = useState<StandingsData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<StandingsData>('standings');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const standings = result.data;
+      setData(standings);
+
+      if (!standings.teams || standings.teams.length === 0) {
+        setStatus('empty');
+        return;
+      }
+
+      setStatus('ok');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <EmptyState baseUrl={baseUrl} />;
+
+  const teams = sortStandings(data.teams);
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8" data-testid="standings-container">
+      <StandingsHero season={data.season} phase={data.phase} currentWeek={data.currentWeek} />
+
+      {/* Mobile：每隊一張卡片堆疊 */}
+      <section className="md:hidden px-4 space-y-3">
+        {teams.map((team) => (
+          <StandingsCard key={team.team} team={team} baseUrl={baseUrl} />
+        ))}
+      </section>
+
+      {/* Desktop：橫排 table */}
+      <section className="hidden md:block px-8 mt-4">
+        <table className="w-full border-collapse bg-white rounded-2xl overflow-hidden">
+          <thead className="bg-warm-1 text-left text-sm text-txt-mid">
+            <tr>
+              <th className="px-4 py-2 font-bold">#</th>
+              <th className="px-4 py-2 font-bold">隊伍</th>
+              <th className="px-4 py-2 font-bold">勝</th>
+              <th className="px-4 py-2 font-bold">敗</th>
+              <th className="px-4 py-2 font-bold">勝率</th>
+              <th className="px-4 py-2 font-bold">最近 6 場</th>
+              <th className="px-4 py-2 font-bold">連勝紀錄</th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team) => (
+              <StandingsTableRow key={team.team} team={team} baseUrl={baseUrl} />
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}
+```
+
+```astro
+---
+// src/pages/standings.astro（覆蓋既有佔位內容）
+import Layout from '../layouts/Layout.astro';
+import { StandingsApp } from '../components/standings/StandingsApp';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<Layout title="戰績榜" active="standings">
+  <StandingsApp client:load baseUrl={baseUrl} />
+</Layout>
+```
+
+- [ ] **Step 4：確認 build + dev server 可預覽**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-3
+npx vitest run                                    # 既有 25 + 新增 16 = 41 cases 全部 PASS
+npm run build                                     # Astro build 5 pages 成功
+# 跑 features e2e 驗證頁面行為（dev server 自動由 playwright 啟動）
+npx playwright test tests/e2e/features/standings.spec.ts --project=features 2>&1 | tail -20
+```
+
+預期：
+- vitest run：41 passed
+- npm run build：5 pages 產出無錯誤
+- playwright run：tests/e2e/features/standings.spec.ts 通過（mobile-only / desktop-only test 由 project skip 控制）
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/standings/StandingsApp.tsx src/pages/standings.astro
+git commit -m "feat(standings): wire StandingsApp into /standings page (#3)"
+```
+
+---
+
+## Self-review
+
+1. **Spec 覆蓋**：AC-1~14 全部由 Task 4 的整合渲染 + Task 3 的 row + Task 2 的狀態元件覆蓋；qa-v2 補的 AC-11b / AC-12b 由 retry button 與 EmptyState 連結覆蓋。✅
+2. **佔位符掃描**：無 TBD / TODO / "Similar to Task N"。✅
+3. **測試約束**：U-1~U-5 全在 Task 1 直接驗實際回傳值（無 spy-only 斷言）；I-1/I-2 走真實 fetch path（vi.fn 只 mock fetch 邊界）；E-* 由 Playwright 在實際瀏覽器跑。✅
+4. **型別一致性**：Task 1 的 `StandingsData` / `TeamStanding` 全 task 共用；`buildRosterLink` 接 `team` (字串)、回傳 `/roster?team=<id>`，與 E2E 的 `?team=green` 斷言對齊。✅
+
+個人風格規則：命中 2 條 — style-rwd-list, style-skeleton-loading

--- a/src/components/standings/EmptyState.tsx
+++ b/src/components/standings/EmptyState.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  baseUrl: string;
+  message?: string;
+}
+
+export function EmptyState({ baseUrl, message = '賽季尚未開始 ⛹️' }: Props) {
+  const rosterHref = `${baseUrl.replace(/\/$/, '')}/roster`;
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <p className="text-lg text-txt-dark mb-6">{message}</p>
+      <a
+        href={rosterHref}
+        className="inline-block px-6 py-2 bg-navy text-white rounded-lg font-bold hover:bg-navy-2 transition"
+      >
+        看球員名單
+      </a>
+    </div>
+  );
+}

--- a/src/components/standings/ErrorState.tsx
+++ b/src/components/standings/ErrorState.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  onRetry: () => void;
+  message?: string;
+}
+
+export function ErrorState({ onRetry, message = '無法載入戰績' }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">{message}</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}

--- a/src/components/standings/SkeletonState.tsx
+++ b/src/components/standings/SkeletonState.tsx
@@ -1,0 +1,22 @@
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse">
+      {/* Hero skeleton */}
+      <div data-testid="skeleton-hero" className="text-center mb-6">
+        <div className="h-10 w-40 bg-gray-200 rounded mx-auto mb-3" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+
+      {/* 6 列灰塊 — mobile 每張卡 / desktop 每列 */}
+      <div className="space-y-3 md:space-y-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            data-testid="skeleton-row"
+            className="h-16 md:h-12 bg-gray-200 rounded-2xl md:rounded"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/standings/StandingsApp.tsx
+++ b/src/components/standings/StandingsApp.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { StandingsData } from '../../types/standings';
+import { fetchData } from '../../lib/api';
+import { sortStandings } from '../../lib/standings-utils';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { StandingsHero } from './StandingsHero';
+import { StandingsCard, StandingsTableRow } from './StandingsRow';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function StandingsApp({ baseUrl }: Props) {
+  const [data, setData] = useState<StandingsData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<StandingsData>('standings');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const standings = result.data;
+      setData(standings);
+
+      if (!standings.teams || standings.teams.length === 0) {
+        setStatus('empty');
+        return;
+      }
+
+      setStatus('ok');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => {
+    setReloadKey((k) => k + 1);
+  }, []);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <EmptyState baseUrl={baseUrl} />;
+
+  const teams = sortStandings(data.teams);
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8" data-testid="standings-container">
+      <StandingsHero season={data.season} phase={data.phase} currentWeek={data.currentWeek} />
+
+      {/* Mobile：每隊一張卡片堆疊 */}
+      <section className="md:hidden px-4 space-y-3">
+        {teams.map((team) => (
+          <StandingsCard key={team.team} team={team} baseUrl={baseUrl} />
+        ))}
+      </section>
+
+      {/* Desktop：橫排 table */}
+      <section className="hidden md:block px-8 mt-4">
+        <table className="w-full border-collapse bg-white rounded-2xl overflow-hidden">
+          <thead className="bg-warm-1 text-left text-sm text-txt-mid">
+            <tr>
+              <th className="px-4 py-2 font-bold">#</th>
+              <th className="px-4 py-2 font-bold">隊伍</th>
+              <th className="px-4 py-2 font-bold">勝</th>
+              <th className="px-4 py-2 font-bold">敗</th>
+              <th className="px-4 py-2 font-bold">勝率</th>
+              <th className="px-4 py-2 font-bold">最近 6 場</th>
+              <th className="px-4 py-2 font-bold">連勝紀錄</th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team) => (
+              <StandingsTableRow key={team.team} team={team} baseUrl={baseUrl} />
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/src/components/standings/StandingsHero.tsx
+++ b/src/components/standings/StandingsHero.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  season: number;
+  phase: string;
+  currentWeek: number;
+}
+
+export function StandingsHero({ season, phase, currentWeek }: Props) {
+  return (
+    <header className="text-center px-4 py-6 md:py-10">
+      <h1 className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        STANDINGS · {phase}
+      </h1>
+      <div className="font-condensed text-base md:text-lg text-txt-mid">
+        第 {season} 季 · 第 {currentWeek} 週
+      </div>
+    </header>
+  );
+}

--- a/src/components/standings/StandingsRow.tsx
+++ b/src/components/standings/StandingsRow.tsx
@@ -1,0 +1,115 @@
+// src/components/standings/StandingsRow.tsx
+import type { TeamStanding } from '../../types/standings';
+import {
+  buildRosterLink,
+  getHistoryDotColor,
+  getStreakClasses,
+} from '../../lib/standings-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  team: TeamStanding;
+  baseUrl: string;
+}
+
+function HistoryDots({ team, history }: { team: string; history: TeamStanding['history'] }) {
+  return (
+    <div data-testid="history" className="flex gap-1">
+      {history.map((r, i) => (
+        <span
+          key={i}
+          data-testid="history-dot"
+          data-result={r}
+          className="w-2.5 h-2.5 rounded-full inline-block"
+          style={{ backgroundColor: getHistoryDotColor(r, team) }}
+          aria-label={r === 'W' ? '勝' : '敗'}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StreakLabel({ team }: { team: TeamStanding }) {
+  const { colorClass, arrow } = getStreakClasses(team.streakType);
+  return (
+    <span
+      data-testid="streak"
+      data-streak-type={team.streakType}
+      className={`font-condensed text-sm ${colorClass}`}
+    >
+      {team.streak}
+      {arrow && <span aria-hidden="true"> {arrow}</span>}
+    </span>
+  );
+}
+
+function rowAriaLabel(t: TeamStanding) {
+  return `${t.name} 第 ${t.rank} 名 ${t.wins} 勝 ${t.losses} 敗`;
+}
+
+/** Mobile card 模式 */
+export function StandingsCard({ team, baseUrl }: Props) {
+  const config = TEAM_CONFIG[team.team];
+  const href = `${baseUrl.replace(/\/$/, '')}${buildRosterLink(team.team)}`;
+  return (
+    <a
+      href={href}
+      data-testid="standings-row"
+      aria-label={rowAriaLabel(team)}
+      className="block bg-white border border-warm-2 rounded-2xl p-4 hover:border-orange transition"
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <span data-testid="rank" className="font-display text-2xl text-txt-dark w-8">
+          {team.rank}
+        </span>
+        <span
+          data-testid="team-dot"
+          className="w-3 h-3 rounded-full"
+          style={{ backgroundColor: config?.color ?? '#999' }}
+        />
+        <span data-testid="team-name" className="font-bold text-lg">
+          {team.team}
+        </span>
+        <span className="ml-auto"><StreakLabel team={team} /></span>
+      </div>
+      <div className="flex items-center gap-4 text-sm text-txt-mid">
+        <span><span data-testid="wins" className="font-bold text-txt-dark">{team.wins}</span> 勝</span>
+        <span><span data-testid="losses" className="font-bold text-txt-dark">{team.losses}</span> 敗</span>
+        <span data-testid="pct" className="font-condensed">{team.pct}</span>
+        <span className="ml-auto"><HistoryDots team={team.team} history={team.history} /></span>
+      </div>
+    </a>
+  );
+}
+
+/** Desktop table row 模式 */
+export function StandingsTableRow({ team, baseUrl }: Props) {
+  const config = TEAM_CONFIG[team.team];
+  const href = `${baseUrl.replace(/\/$/, '')}${buildRosterLink(team.team)}`;
+  return (
+    <tr
+      data-testid="standings-row"
+      onClick={() => { window.location.href = href; }}
+      role="link"
+      aria-label={rowAriaLabel(team)}
+      className="cursor-pointer hover:bg-warm-1 transition border-b border-warm-2"
+    >
+      <td data-testid="rank" className="font-display text-2xl px-4 py-3">{team.rank}</td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span
+            data-testid="team-dot"
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: config?.color ?? '#999' }}
+          />
+          <span data-testid="team-name" className="font-bold">{team.team}</span>
+        </div>
+      </td>
+      <td data-testid="wins" className="px-4 py-3 font-condensed">{team.wins}</td>
+      <td data-testid="losses" className="px-4 py-3 font-condensed">{team.losses}</td>
+      <td data-testid="pct" className="px-4 py-3 font-condensed">{team.pct}</td>
+      <td className="px-4 py-3"><HistoryDots team={team.team} history={team.history} /></td>
+      <td className="px-4 py-3"><StreakLabel team={team} /></td>
+    </tr>
+  );
+}

--- a/src/lib/standings-utils.ts
+++ b/src/lib/standings-utils.ts
@@ -1,0 +1,38 @@
+import type { HistoryResult, StreakType, TeamStanding } from '../types/standings';
+import { TEAM_CONFIG } from '../config/teams';
+
+const GREY = '#999999';
+
+export function formatPct(wins: number, losses: number): string {
+  const total = wins + losses;
+  if (total === 0) return '—';
+  return `${((wins / total) * 100).toFixed(1)}%`;
+}
+
+export interface StreakStyle {
+  colorClass: string;
+  arrow: '↑' | '↓' | '';
+}
+
+export function getStreakClasses(type: StreakType): StreakStyle {
+  if (type === 'win') return { colorClass: 'text-orange', arrow: '↑' };
+  if (type === 'lose') return { colorClass: 'text-red-600', arrow: '↓' };
+  return { colorClass: 'text-txt-mid', arrow: '' };
+}
+
+export function getHistoryDotColor(result: HistoryResult, teamId: string): string {
+  if (result === 'L') return GREY;
+  const team = TEAM_CONFIG[teamId];
+  return team?.color ?? GREY;
+}
+
+/** 不重排，identity — 防止未來誤加排序 */
+export function sortStandings(teams: TeamStanding[]): TeamStanding[] {
+  return [...teams];
+}
+
+export function buildRosterLink(teamId: string): string {
+  const team = TEAM_CONFIG[teamId];
+  if (!team) return '/roster';
+  return `/roster?team=${team.id}`;
+}

--- a/src/pages/standings.astro
+++ b/src/pages/standings.astro
@@ -1,14 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { StandingsApp } from '../components/standings/StandingsApp';
+
+const baseUrl = import.meta.env.BASE_URL;
 ---
 
 <Layout title="戰績榜" active="standings">
-  <section class="px-4 md:px-8 py-8 max-w-6xl mx-auto">
-    <h1 class="font-display text-3xl md:text-5xl text-navy tracking-wider mb-2">戰績</h1>
-    <p class="text-txt-mid mb-8">六隊本季戰績、勝率、淨勝分</p>
-
-    <div class="bg-white border border-warm-2 rounded-2xl p-8 text-center">
-      <p class="font-condensed text-2xl text-orange mb-2">規劃中</p>
-    </div>
-  </section>
+  <StandingsApp client:load baseUrl={baseUrl} />
 </Layout>

--- a/src/types/standings.ts
+++ b/src/types/standings.ts
@@ -1,0 +1,22 @@
+export type StreakType = 'win' | 'lose' | 'none';
+export type HistoryResult = 'W' | 'L';
+
+export interface TeamStanding {
+  rank: number;
+  name: string;     // 「綠隊」
+  team: string;     // 「綠」（對應 TEAM_CONFIG key）
+  wins: number;
+  losses: number;
+  pct: string;
+  history: HistoryResult[];
+  streak: string;
+  streakType: StreakType;
+}
+
+export interface StandingsData {
+  season: number;
+  phase: string;
+  currentWeek: number;
+  teams: TeamStanding[];
+  matrix?: unknown;
+}

--- a/tests/e2e/features/standings.spec.ts
+++ b/tests/e2e/features/standings.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * /standings 戰績榜頁 E2E
+ *
+ * Tag: @standings
+ * Coverage: AC-1 ~ AC-14（全部）+ qa-v2 補充
+ *
+ * 測試資料策略：
+ * - 預設用 mockStandingsAPI() 攔截 GAS 與 fallback JSON 請求
+ * - 不會打 production Google Sheets
+ * - 各情境用 fixtures/standings.ts 的工廠函式建立
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  mockFullStandings,
+  mockEmptyStandings,
+  mockZeroRecordStandings,
+  mockEightTeamStandings,
+} from '../../fixtures/standings';
+import { mockStandingsAPI } from '../../helpers/mock-api';
+
+test.describe('Standings Page @standings', () => {
+  // ────── AC-1: Hero 標題 + 副標 + 6 隊戰績 ──────
+  test('AC-1: Hero「STANDINGS · 例行賽」+「第 25 季 · 第 5 週」+ 6 隊戰績榜', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    // UI 結構
+    await expect(page.getByRole('heading', { name: /STANDINGS/i })).toBeVisible();
+    await expect(page.getByText(/例行賽/)).toBeVisible();
+    await expect(page.getByText(/第\s*25\s*季/)).toBeVisible();
+    await expect(page.getByText(/第\s*5\s*週/)).toBeVisible();
+
+    // 6 隊
+    const rows = page.locator('[data-testid="standings-row"]');
+    await expect(rows).toHaveCount(6);
+  });
+
+  // ────── AC-2: 每列 7 個欄位 ──────
+  test('AC-2: 每列顯示 rank、隊伍色點+名、勝、敗、勝率、history、連勝紀錄', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    const firstRow = page.locator('[data-testid="standings-row"]').first();
+
+    await expect(firstRow.locator('[data-testid="rank"]')).toContainText('1');
+    await expect(firstRow.locator('[data-testid="team-dot"]')).toBeVisible();
+    await expect(firstRow.locator('[data-testid="team-name"]')).toContainText('綠');
+    await expect(firstRow.locator('[data-testid="wins"]')).toContainText('4');
+    await expect(firstRow.locator('[data-testid="losses"]')).toContainText('2');
+    await expect(firstRow.locator('[data-testid="pct"]')).toContainText('66.7');
+    await expect(firstRow.locator('[data-testid="history"] [data-testid="history-dot"]')).toHaveCount(6);
+    await expect(firstRow.locator('[data-testid="streak"]')).toContainText(/2連勝/);
+  });
+
+  // ────── AC-3: 連勝顏色 + ↑ ──────
+  test('AC-3: 連勝隊伍 streak 文字以橙色顯示 + 上箭頭 icon', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    // 綠隊（rank 1）連勝
+    const greenStreak = page
+      .locator('[data-testid="standings-row"]')
+      .filter({ has: page.locator('[data-testid="team-name"]', { hasText: '綠' }) })
+      .locator('[data-testid="streak"]');
+
+    await expect(greenStreak).toHaveAttribute('data-streak-type', 'win');
+    await expect(greenStreak).toContainText('↑');
+    const color = await greenStreak.evaluate((el) => getComputedStyle(el).color);
+    // 橙色 RGB 大致範圍：R 高、G 中、B 低
+    expect(color).toMatch(/rgb\(/);
+  });
+
+  // ────── AC-4: 連敗顏色 + ↓ ──────
+  test('AC-4: 連敗隊伍 streak 文字以紅色顯示 + 下箭頭 icon', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    // 紅隊（rank 2）連敗
+    const redStreak = page
+      .locator('[data-testid="standings-row"]')
+      .filter({ has: page.locator('[data-testid="team-name"]', { hasText: '紅' }) })
+      .locator('[data-testid="streak"]');
+
+    await expect(redStreak).toHaveAttribute('data-streak-type', 'lose');
+    await expect(redStreak).toContainText('↓');
+  });
+
+  // ────── AC-5: history 圓點配色 ──────
+  test('AC-5: history 圓點 → 勝場顯隊伍主色、敗場顯灰色', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    // 綠隊 history: ['L','W','W','L','W','W']
+    const greenRow = page
+      .locator('[data-testid="standings-row"]')
+      .filter({ has: page.locator('[data-testid="team-name"]', { hasText: '綠' }) });
+
+    const dots = greenRow.locator('[data-testid="history-dot"]');
+    await expect(dots).toHaveCount(6);
+
+    // 第 1 顆（L → grey）vs 第 2 顆（W → green team color）
+    await expect(dots.nth(0)).toHaveAttribute('data-result', 'L');
+    await expect(dots.nth(1)).toHaveAttribute('data-result', 'W');
+  });
+
+  // ────── AC-6: 點隊伍列 → /roster?team=<id> ──────
+  test('AC-6: 點擊隊伍列 → 導向 /roster?team=<隊伍id>', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    const greenRow = page
+      .locator('[data-testid="standings-row"]')
+      .filter({ has: page.locator('[data-testid="team-name"]', { hasText: '綠' }) });
+
+    await greenRow.click();
+    await expect(page).toHaveURL(/\/roster\?team=green/);
+  });
+
+  // ────── AC-7: rank 順序與輸入完全一致 ──────
+  test('AC-7: rank 順序完全照後台給的值（前端不重排，即使勝率相同）', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    const teamNames = await page
+      .locator('[data-testid="standings-row"] [data-testid="team-name"]')
+      .allTextContents();
+
+    expect(teamNames.map((s) => s.trim())).toEqual(['綠', '紅', '黑', '黃', '白', '藍']);
+  });
+
+  // ────── AC-10: Loading state ──────
+  test('AC-10: 資料載入中 → skeleton（Hero 灰塊 + 6 列灰塊閃爍）', async ({ page }) => {
+    await mockStandingsAPI(page, mockFullStandings(), { delayMs: 1500 });
+    await page.goto('standings');
+
+    await expect(page.locator('[data-testid="skeleton-hero"]')).toBeVisible();
+    await expect(page.locator('[data-testid="skeleton-row"]').first()).toBeVisible();
+
+    // 資料載入後 skeleton 消失
+    await expect(page.locator('[data-testid="standings-row"]').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="skeleton-row"]')).toHaveCount(0);
+  });
+
+  // ────── AC-11: Error state ──────
+  test('AC-11: GAS + JSON 都失敗 → 顯示「無法載入戰績」+ 重試按鈕', async ({ page }) => {
+    await mockStandingsAPI(page, null, { allFail: true });
+    await page.goto('standings');
+
+    await expect(page.getByText(/無法載入戰績/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
+  });
+
+  // ────── AC-11 [qa-v2 補充]：點重試按鈕重新嘗試 ──────
+  test('[qa-v2 補充] AC-11b: 點重試按鈕 → 重新嘗試載入', async ({ page }) => {
+    let callCount = 0;
+    await page.route(/script\.google\.com.*exec/, async (route) => {
+      callCount++;
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+    await page.route(/\/data\/standings\.json/, async (route) => {
+      callCount++;
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+
+    await page.goto('standings');
+    await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
+
+    const initialCount = callCount;
+    await page.getByRole('button', { name: /重試/ }).click();
+
+    await expect.poll(() => callCount).toBeGreaterThan(initialCount);
+  });
+
+  // ────── AC-12: Empty state ──────
+  test('AC-12: 賽季尚未開始 → 「賽季尚未開始 ⛹️」+「看球員名單」按鈕', async ({ page }) => {
+    await mockStandingsAPI(page, mockEmptyStandings());
+    await page.goto('standings');
+
+    await expect(page.getByText(/賽季尚未開始/)).toBeVisible();
+    await expect(page.getByRole('link', { name: /看球員名單/ })).toBeVisible();
+  });
+
+  // ────── AC-12 [qa-v2 補充]：empty 按鈕導向 /roster ──────
+  test('[qa-v2 補充] AC-12b: 點「看球員名單」→ 導向 /roster', async ({ page }) => {
+    await mockStandingsAPI(page, mockEmptyStandings());
+    await page.goto('standings');
+
+    await page.getByRole('link', { name: /看球員名單/ }).click();
+    await expect(page).toHaveURL(/\/roster/);
+  });
+
+  // ────── AC-13: 0勝 0敗 → 勝率「—」 ──────
+  test('AC-13: 0勝 0敗的隊（剛開賽）→ 勝率顯示「—」', async ({ page }) => {
+    await mockStandingsAPI(page, mockZeroRecordStandings());
+    await page.goto('standings');
+
+    const firstRow = page.locator('[data-testid="standings-row"]').first();
+    await expect(firstRow.locator('[data-testid="pct"]')).toContainText('—');
+    await expect(firstRow.locator('[data-testid="pct"]')).not.toContainText('0.0');
+  });
+
+  // ────── AC-14: > 6 隊不爆版 ──────
+  test('AC-14: 8 隊資料 → 排版正常（不爆版，所有列可見）', async ({ page }) => {
+    await mockStandingsAPI(page, mockEightTeamStandings());
+    await page.goto('standings');
+
+    const rows = page.locator('[data-testid="standings-row"]');
+    await expect(rows).toHaveCount(8);
+
+    // 容器寬度應大於每列內容寬度（避免水平 overflow）
+    const container = page.locator('[data-testid="standings-container"]');
+    const containerBox = await container.boundingBox();
+    const lastRowBox = await rows.last().boundingBox();
+    expect(lastRowBox?.x ?? 0).toBeGreaterThanOrEqual(containerBox?.x ?? 0);
+    expect((lastRowBox?.x ?? 0) + (lastRowBox?.width ?? 0)).toBeLessThanOrEqual(
+      (containerBox?.x ?? 0) + (containerBox?.width ?? 0) + 1,
+    );
+  });
+});
+
+// ────── AC-8 / AC-9: RWD ──────
+test.describe('Standings Page RWD @standings', () => {
+  test('AC-8 (regression-mobile): 手機 → 6 張卡片垂直堆疊', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width >= 768, 'mobile project only');
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    const rows = page.locator('[data-testid="standings-row"]');
+    await expect(rows).toHaveCount(6);
+
+    // 卡片垂直排列：第一張和第二張的 X 座標接近、Y 座標遞增
+    const box1 = await rows.nth(0).boundingBox();
+    const box2 = await rows.nth(1).boundingBox();
+    expect(Math.abs((box1?.x ?? 0) - (box2?.x ?? 0))).toBeLessThan(20);
+    expect((box2?.y ?? 0)).toBeGreaterThan(box1?.y ?? 0);
+  });
+
+  test('AC-9 (regression desktop): 桌機 → 橫排表格 6 列', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 768, 'desktop project only');
+    await mockStandingsAPI(page, mockFullStandings());
+    await page.goto('standings');
+
+    const rows = page.locator('[data-testid="standings-row"]');
+    await expect(rows).toHaveCount(6);
+
+    // 桌機應為單一橫排表格容器：所有列 X 座標接近、Y 座標遞增
+    const box1 = await rows.nth(0).boundingBox();
+    const box2 = await rows.nth(1).boundingBox();
+    expect(Math.abs((box1?.x ?? 0) - (box2?.x ?? 0))).toBeLessThan(20);
+    expect((box2?.y ?? 0)).toBeGreaterThan(box1?.y ?? 0);
+
+    // 桌機表格寬度應 ≥ 600 (rough 桌機 layout 判斷)
+    expect(box1?.width ?? 0).toBeGreaterThan(400);
+  });
+});

--- a/tests/fixtures/standings.ts
+++ b/tests/fixtures/standings.ts
@@ -1,0 +1,137 @@
+/**
+ * Standings fixture 工廠
+ *
+ * 提供測試專用的固定範例資料，含正常情境與邊界情境。
+ * 不會打 production Google Sheets，所有測試資料均在此手寫。
+ */
+
+export type StreakType = 'win' | 'lose' | 'none';
+export type HistoryResult = 'W' | 'L';
+
+export interface TeamStanding {
+  rank: number;
+  /** 隊伍全名（例：「綠隊」） */
+  name: string;
+  /** 隊伍 ID（單字，對應 TEAM_CONFIG key，例：「綠」） */
+  team: string;
+  wins: number;
+  losses: number;
+  pct: string;
+  history: HistoryResult[];
+  streak: string;
+  streakType: StreakType;
+}
+
+export interface StandingsData {
+  season: number;
+  phase: string;
+  currentWeek: number;
+  teams: TeamStanding[];
+  matrix?: unknown;
+}
+
+/** 建立單一隊伍 standing */
+export function mockTeamStanding(overrides: Partial<TeamStanding> = {}): TeamStanding {
+  return {
+    rank: 1,
+    name: '綠隊',
+    team: '綠',
+    wins: 4,
+    losses: 2,
+    pct: '66.7%',
+    history: ['L', 'W', 'W', 'L', 'W', 'W'],
+    streak: '2連勝',
+    streakType: 'win',
+    ...overrides,
+  };
+}
+
+/** 完整 6 隊聯盟戰績（與 public/data/standings.json 結構一致，含連勝、連敗、混合） */
+export function mockFullStandings(): StandingsData {
+  return {
+    season: 25,
+    phase: '例行賽',
+    currentWeek: 5,
+    teams: [
+      {
+        rank: 1, name: '綠隊', team: '綠',
+        wins: 4, losses: 2, pct: '66.7%',
+        history: ['L', 'W', 'W', 'L', 'W', 'W'],
+        streak: '2連勝', streakType: 'win',
+      },
+      {
+        rank: 2, name: '紅隊', team: '紅',
+        wins: 4, losses: 2, pct: '66.7%',
+        history: ['W', 'L', 'W', 'W', 'W', 'L'],
+        streak: '1連敗', streakType: 'lose',
+      },
+      {
+        rank: 3, name: '黑隊', team: '黑',
+        wins: 3, losses: 3, pct: '50.0%',
+        history: ['L', 'W', 'L', 'W', 'W', 'W'],
+        streak: '2連勝', streakType: 'win',
+      },
+      {
+        rank: 4, name: '黃隊', team: '黃',
+        wins: 3, losses: 3, pct: '50.0%',
+        history: ['W', 'W', 'L', 'L', 'L', 'W'],
+        streak: '1連勝', streakType: 'win',
+      },
+      {
+        rank: 5, name: '白隊', team: '白',
+        wins: 3, losses: 3, pct: '50.0%',
+        history: ['L', 'W', 'W', 'W', 'L', 'L'],
+        streak: '2連敗', streakType: 'lose',
+      },
+      {
+        rank: 6, name: '藍隊', team: '藍',
+        wins: 1, losses: 5, pct: '16.7%',
+        history: ['L', 'L', 'W', 'L', 'L', 'L'],
+        streak: '3連敗', streakType: 'lose',
+      },
+    ],
+  };
+}
+
+/** 空賽季（賽季尚未開始） */
+export function mockEmptyStandings(): StandingsData {
+  return {
+    season: 25,
+    phase: '例行賽',
+    currentWeek: 0,
+    teams: [],
+  };
+}
+
+/** 0勝 0敗的隊（剛開賽，pct 應顯示「—」） */
+export function mockZeroRecordStandings(): StandingsData {
+  return {
+    season: 25,
+    phase: '例行賽',
+    currentWeek: 1,
+    teams: Array.from({ length: 6 }, (_, i) => ({
+      rank: i + 1,
+      name: ['綠隊', '紅隊', '黑隊', '黃隊', '白隊', '藍隊'][i],
+      team: ['綠', '紅', '黑', '黃', '白', '藍'][i],
+      wins: 0,
+      losses: 0,
+      pct: '—',
+      history: [],
+      streak: '',
+      streakType: 'none' as StreakType,
+    })),
+  };
+}
+
+/** 8 隊（未來支援更多隊測試排版） */
+export function mockEightTeamStandings(): StandingsData {
+  const base = mockFullStandings();
+  return {
+    ...base,
+    teams: [
+      ...base.teams,
+      mockTeamStanding({ rank: 7, name: '紫隊', team: '紫', pct: '14.3%', wins: 1, losses: 6 }),
+      mockTeamStanding({ rank: 8, name: '橙隊', team: '橙', pct: '0.0%', wins: 0, losses: 7 }),
+    ],
+  };
+}

--- a/tests/helpers/mock-api.ts
+++ b/tests/helpers/mock-api.ts
@@ -6,58 +6,41 @@
  *   await mockScheduleAPI(page, null, { gasFails: true });    // GAS 失敗 → fallback JSON
  *   await mockScheduleAPI(page, null, { allFail: true });     // GAS + JSON 都失敗
  *   await mockScheduleAPI(page, schedule, { delayMs: 2000 }); // 延遲 2 秒模擬載入
+ *
+ *   await mockStandingsAPI(page, mockFullStandings());        // 戰績榜
  */
 
 import type { Page, Route } from '@playwright/test';
 import type { ScheduleData } from '../fixtures/schedule';
+import type { StandingsData } from '../fixtures/standings';
 
-interface MockOptions {
+interface MockOptions<T> {
   /** GAS 是否失敗（true 時會 fallback 到 JSON） */
   gasFails?: boolean;
   /** GAS + JSON 都失敗 */
   allFail?: boolean;
   /** 延遲毫秒數（模擬慢速網路） */
   delayMs?: number;
-  /** 自訂 JSON fallback 內容（不指定就用 schedule 同一份） */
-  fallbackJson?: ScheduleData;
+  /** 自訂 JSON fallback 內容（不指定就用 data 同一份） */
+  fallbackJson?: T;
 }
 
 const GAS_PATTERN = /script\.google\.com\/macros\/s\/.+\/exec/;
-const JSON_PATTERN = /\/data\/schedule\.json$/;
 
-export async function mockScheduleAPI(
+async function mockKindAPI<T>(
   page: Page,
-  schedule: ScheduleData | null,
-  opts: MockOptions = {},
+  jsonPattern: RegExp,
+  data: T | null,
+  opts: MockOptions<T> = {},
 ): Promise<void> {
   const { gasFails = false, allFail = false, delayMs = 0, fallbackJson } = opts;
 
-  // 攔截 GAS 請求
   await page.route(GAS_PATTERN, async (route: Route) => {
     if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
     if (allFail || gasFails) {
       await route.fulfill({ status: 500, body: 'GAS error' });
       return;
     }
-    if (schedule) {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(schedule),
-      });
-      return;
-    }
-    await route.fulfill({ status: 500, body: 'No data' });
-  });
-
-  // 攔截 fallback JSON 請求
-  await page.route(JSON_PATTERN, async (route: Route) => {
-    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
-    if (allFail) {
-      await route.fulfill({ status: 500, body: 'JSON fallback failed' });
-      return;
-    }
-    const data = fallbackJson ?? schedule;
     if (data) {
       await route.fulfill({
         status: 200,
@@ -66,6 +49,40 @@ export async function mockScheduleAPI(
       });
       return;
     }
-    await route.continue(); // 沒指定就放行（讀真實 public/data/schedule.json）
+    await route.fulfill({ status: 500, body: 'No data' });
   });
+
+  await page.route(jsonPattern, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (allFail) {
+      await route.fulfill({ status: 500, body: 'JSON fallback failed' });
+      return;
+    }
+    const fallback = fallbackJson ?? data;
+    if (fallback) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(fallback),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+export async function mockScheduleAPI(
+  page: Page,
+  schedule: ScheduleData | null,
+  opts: MockOptions<ScheduleData> = {},
+): Promise<void> {
+  return mockKindAPI<ScheduleData>(page, /\/data\/schedule\.json$/, schedule, opts);
+}
+
+export async function mockStandingsAPI(
+  page: Page,
+  standings: StandingsData | null,
+  opts: MockOptions<StandingsData> = {},
+): Promise<void> {
+  return mockKindAPI<StandingsData>(page, /\/data\/standings\.json$/, standings, opts);
 }

--- a/tests/integration/api-fallback.integration.test.ts
+++ b/tests/integration/api-fallback.integration.test.ts
@@ -1,12 +1,13 @@
 /**
  * Integration: src/lib/api.ts 三層 fallback 行為
  *
- * Tag: @api-fallback @schedule
+ * Tag: @api-fallback @schedule @standings
  * Coverage: 涵蓋 AC-11（GAS 失敗 → JSON fallback → 全失敗）的後端邏輯部分
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { mockFullSchedule } from '../fixtures/schedule';
+import { mockFullStandings } from '../fixtures/standings';
 
 // 動態 mock import.meta.env 與 fetch
 const ORIG_FETCH = globalThis.fetch;
@@ -95,5 +96,47 @@ describe('api.ts 三層 fallback (integration)', () => {
 
     expect(gasCalled).toBe(false);
     expect(result.source).toBe('static');
+  });
+
+  // Covers: I-2（standings）— 確認 fetchData('standings') 走 GAS → JSON fallback
+  it('standings: GAS 失敗 → 從 standings.json fallback（source: static）', async () => {
+    const standings = mockFullStandings();
+    globalThis.fetch = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('script.google.com')) {
+        return new Response('GAS error', { status: 500 });
+      }
+      if (u.includes('standings.json')) {
+        return new Response(JSON.stringify(standings), { status: 200 });
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData<typeof standings>('standings');
+
+    expect(result.source).toBe('static');
+    expect(result.data?.teams).toHaveLength(6);
+    expect(result.data?.phase).toBe('例行賽');
+  });
+
+  // Covers: I-3（standings）— GAS + JSON 都失敗 → source: error
+  it('standings: GAS + JSON 都失敗 → source: error（驅動 UI error state）', async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('script.google.com')) {
+        return new Response('GAS error', { status: 500 });
+      }
+      if (u.includes('standings.json')) {
+        return new Response('not found', { status: 404 });
+      }
+      throw new Error(`unexpected: ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('standings');
+
+    expect(result.source).toBe('error');
+    expect(result.data).toBeNull();
   });
 });

--- a/tests/unit/standings-components.test.ts
+++ b/tests/unit/standings-components.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit smoke test：驗 5 個 React 元件可被 SSR 渲染、不 throw、含關鍵 testid
+ *
+ * 補測 code-review-graph `detect_changes_tool` 標記為 untested 的元件。
+ * 不使用 @testing-library/react（避免新增依賴），改用 react-dom/server.renderToString
+ * 配合 React.createElement（保持 .ts 副檔名相容 vitest 設定）。
+ *
+ * 互動行為（click retry / 點隊伍列）由 tests/e2e/features/standings.spec.ts 覆蓋。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { SkeletonState } from '../../src/components/standings/SkeletonState';
+import { ErrorState } from '../../src/components/standings/ErrorState';
+import { EmptyState } from '../../src/components/standings/EmptyState';
+import { StandingsHero } from '../../src/components/standings/StandingsHero';
+import { StandingsApp } from '../../src/components/standings/StandingsApp';
+import { StandingsCard, StandingsTableRow } from '../../src/components/standings/StandingsRow';
+import { mockTeamStanding } from '../fixtures/standings';
+
+describe('standings components smoke', () => {
+  // Covers: SkeletonState（test_gap）
+  it('SkeletonState：渲染含 skeleton-hero + 6 個 skeleton-row', () => {
+    const html = renderToString(createElement(SkeletonState));
+    expect(html).toContain('skeleton-hero');
+    expect(html.match(/skeleton-row/g)?.length ?? 0).toBe(6);
+    expect(html).toContain('animate-pulse');
+  });
+
+  // Covers: ErrorState（test_gap）
+  it('ErrorState：預設訊息「無法載入戰績」+ 重試按鈕', () => {
+    const html = renderToString(createElement(ErrorState, { onRetry: () => {} }));
+    expect(html).toContain('無法載入戰績');
+    expect(html).toContain('重試');
+  });
+
+  it('ErrorState：可覆寫訊息文字', () => {
+    const html = renderToString(
+      createElement(ErrorState, { onRetry: () => {}, message: '網路怪怪的' }),
+    );
+    expect(html).toContain('網路怪怪的');
+  });
+
+  // Covers: EmptyState（test_gap）
+  it('EmptyState：顯示「賽季尚未開始」+「看球員名單」連結 → /roster', () => {
+    const html = renderToString(createElement(EmptyState, { baseUrl: '/' }));
+    expect(html).toContain('賽季尚未開始');
+    expect(html).toContain('看球員名單');
+    expect(html).toContain('href="/roster"');
+  });
+
+  it('EmptyState：baseUrl 帶子路徑（GitHub Pages）→ link 也帶子路徑', () => {
+    const html = renderToString(
+      createElement(EmptyState, { baseUrl: '/taan-basketball-league/' }),
+    );
+    expect(html).toContain('href="/taan-basketball-league/roster"');
+  });
+
+  // Covers: StandingsHero（test_gap）
+  it('StandingsHero：標題「STANDINGS · 例行賽」+ 副標「第 25 季 · 第 5 週」', () => {
+    const html = renderToString(
+      createElement(StandingsHero, { season: 25, phase: '例行賽', currentWeek: 5 }),
+    );
+    expect(html).toContain('STANDINGS');
+    expect(html).toContain('例行賽');
+    // React SSR 在 text fragment 間插入 <!-- -->，斷言時忽略
+    const stripped = html.replace(/<!--\s*-->/g, '');
+    expect(stripped).toMatch(/第\s*25\s*季/);
+    expect(stripped).toMatch(/第\s*5\s*週/);
+  });
+
+  // Covers: StandingsApp（test_gap）— SSR 預設渲染 skeleton（useEffect 不在 server 端執行）
+  it('StandingsApp：SSR 預設渲染 SkeletonState（loading 為初始狀態）', () => {
+    const html = renderToString(createElement(StandingsApp, { baseUrl: '/' }));
+    expect(html).toContain('skeleton-hero');
+    expect(html).toContain('skeleton-row');
+  });
+
+  // Covers: StandingsCard / HistoryDots / StreakLabel（StandingsRow 內部 helpers，code-graph test_gap）
+  it('StandingsCard：含 7 個關鍵 data-testid + history 6 顆 dot', () => {
+    const team = mockTeamStanding();
+    const html = renderToString(
+      createElement(StandingsCard, { team, baseUrl: '/' }),
+    );
+    expect(html).toContain('data-testid="standings-row"');
+    expect(html).toContain('data-testid="rank"');
+    expect(html).toContain('data-testid="team-dot"');
+    expect(html).toContain('data-testid="team-name"');
+    expect(html).toContain('data-testid="wins"');
+    expect(html).toContain('data-testid="losses"');
+    expect(html).toContain('data-testid="pct"');
+    expect(html).toContain('data-testid="streak"');
+    expect(html.match(/data-testid="history-dot"/g)?.length ?? 0).toBe(6);
+  });
+
+  it('StandingsCard：win streak → data-streak-type="win"，連結指向 /roster?team=<id>', () => {
+    const team = mockTeamStanding({ streakType: 'win', team: '綠' });
+    const html = renderToString(createElement(StandingsCard, { team, baseUrl: '/' }));
+    expect(html).toContain('data-streak-type="win"');
+    expect(html).toContain('href="/roster?team=green"');
+  });
+
+  it('StandingsTableRow：渲染為 <tr> 含 7 欄 + 對應 testid', () => {
+    const team = mockTeamStanding({ team: '紅', streakType: 'lose' });
+    const html = renderToString(createElement(StandingsTableRow, { team, baseUrl: '/' }));
+    expect(html).toContain('data-testid="standings-row"');
+    expect(html).toContain('role="link"');
+    expect(html).toContain('data-streak-type="lose"');
+  });
+
+  it('history-dot：W 顯隊伍主色、L 顯灰色（不同色）', () => {
+    const winnerTeam = mockTeamStanding({ team: '綠', history: ['W', 'L'] });
+    const html = renderToString(
+      createElement(StandingsCard, { team: winnerTeam, baseUrl: '/' }),
+    );
+    // 第一顆 W 應含綠隊主色 #2e7d32；第二顆 L 應為灰
+    expect(html).toContain('#2e7d32');
+    expect(html).toMatch(/#999/);
+  });
+});

--- a/tests/unit/standings-utils.test.ts
+++ b/tests/unit/standings-utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatPct,
+  getStreakClasses,
+  getHistoryDotColor,
+  sortStandings,
+  buildRosterLink,
+} from '../../src/lib/standings-utils';
+import { mockFullStandings, mockZeroRecordStandings } from '../fixtures/standings';
+
+describe('standings-utils', () => {
+  // Covers: U-1 formatPct
+  describe('formatPct', () => {
+    it('0勝 0敗 → 回傳 "—"（避免誤導為 0.0%）', () => {
+      expect(formatPct(0, 0)).toBe('—');
+    });
+
+    it('4勝 2敗 → 回傳 "66.7%"', () => {
+      expect(formatPct(4, 2)).toBe('66.7%');
+    });
+
+    it('1勝 5敗 → 回傳 "16.7%"', () => {
+      expect(formatPct(1, 5)).toBe('16.7%');
+    });
+
+    it('3勝 3敗 → 回傳 "50.0%"', () => {
+      expect(formatPct(3, 3)).toBe('50.0%');
+    });
+  });
+
+  // Covers: U-2 getStreakClasses
+  describe('getStreakClasses', () => {
+    it('win → 含 orange 文字色 + ↑ 箭頭', () => {
+      const result = getStreakClasses('win');
+      expect(result.colorClass).toMatch(/orange/);
+      expect(result.arrow).toBe('↑');
+    });
+
+    it('lose → 含 紅色文字色 + ↓ 箭頭', () => {
+      const result = getStreakClasses('lose');
+      expect(result.colorClass).toMatch(/red/);
+      expect(result.arrow).toBe('↓');
+    });
+
+    it('none → 預設灰色、無箭頭', () => {
+      const result = getStreakClasses('none');
+      expect(result.colorClass).toMatch(/gray|txt-mid/);
+      expect(result.arrow).toBe('');
+    });
+  });
+
+  // Covers: U-3 getHistoryDotColor
+  describe('getHistoryDotColor', () => {
+    it('W + 綠 → 回傳隊伍綠色 hex', () => {
+      // 綠隊主色 #2e7d32（src/config/teams.ts）
+      expect(getHistoryDotColor('W', '綠')).toBe('#2e7d32');
+    });
+
+    it('L + 任何隊 → 回傳灰色（不是隊伍主色）', () => {
+      const grey = getHistoryDotColor('L', '綠');
+      expect(grey).not.toBe('#2e7d32');
+      expect(grey.toLowerCase()).toMatch(/^#[9ab][9ab][9ab]/i); // 灰系 hex（如 #9e9e9e / #aaa）
+    });
+
+    it('未知隊伍 → fallback 到灰（不 throw）', () => {
+      expect(() => getHistoryDotColor('W', '紫')).not.toThrow();
+    });
+  });
+
+  // Covers: U-4 sortStandings（identity，前端不重排）
+  describe('sortStandings', () => {
+    it('回傳順序與輸入完全一致（rank 由後台決定）', () => {
+      const data = mockFullStandings();
+      const sorted = sortStandings(data.teams);
+      expect(sorted.map((t) => t.team)).toEqual(data.teams.map((t) => t.team));
+    });
+
+    it('勝率相同 rank 不同 → 仍照 rank 順序（不重排）', () => {
+      const data = mockFullStandings(); // rank 3,4,5 都是 50.0%
+      const sorted = sortStandings(data.teams);
+      const ties = sorted.filter((t) => t.pct === '50.0%').map((t) => t.team);
+      expect(ties).toEqual(['黑', '黃', '白']);
+    });
+  });
+
+  // Covers: U-5 buildRosterLink
+  describe('buildRosterLink', () => {
+    it('綠隊 → /roster?team=green', () => {
+      expect(buildRosterLink('綠')).toBe('/roster?team=green');
+    });
+
+    it('紅隊 → /roster?team=red', () => {
+      expect(buildRosterLink('紅')).toBe('/roster?team=red');
+    });
+
+    it('未知隊伍 → fallback 到 /roster（無 query）', () => {
+      expect(buildRosterLink('紫')).toBe('/roster');
+    });
+  });
+
+  // Covers: U-1 邊界（zero-record 整體一致性）
+  it('mockZeroRecordStandings 的所有隊 pct 都應為 "—"', () => {
+    const data = mockZeroRecordStandings();
+    data.teams.forEach((t) => {
+      expect(formatPct(t.wins, t.losses)).toBe('—');
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     include: [
-      'tests/unit/**/*.{test,spec}.ts',
-      'tests/integration/**/*.{test,spec}.ts',
+      'tests/unit/**/*.{test,spec}.{ts,tsx}',
+      'tests/integration/**/*.{test,spec}.{ts,tsx}',
     ],
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
實作 `/standings` 戰績榜頁，含 Hero 標題、6 隊排行、history 圓點、連勝/連敗 streak、三狀態與 RWD（mobile 卡片堆疊、desktop 橫排表格），點擊隊伍導向 `/roster?team=<id>`。

關聯 Issue #3。

## Changes
- 新增 `src/types/standings.ts`、`src/lib/standings-utils.ts`（5 個純函式：formatPct / getStreakClasses / getHistoryDotColor / sortStandings / buildRosterLink）
- 新增元件：`SkeletonState` / `ErrorState` / `EmptyState` / `StandingsHero` / `StandingsRow`（含 mobile card + desktop table row 兩個 export）/ `StandingsApp`（state machine 主島）
- 改寫 `src/pages/standings.astro` 為 `<StandingsApp client:load>`，沿用 ScheduleApp pattern
- 擴充 `src/lib/api.ts` 不需動（既有 fetchData 已支援 'standings' kind）
- 測試：tests/fixtures/standings.ts（4 個工廠）、tests/helpers/mock-api.ts（新增 mockStandingsAPI）、tests/integration/api-fallback（新增 standings 兩條 case）、tests/unit/standings-utils.test.ts（16 cases）、tests/unit/standings-components.test.ts（11 SSR smoke cases）、tests/e2e/features/standings.spec.ts（17 cases）
- vitest.config.ts 加入 esbuild jsx automatic + .tsx include

## Test
- Vitest unit + integration: **52/52 passed**（6 test files）
- Astro build: 5 pages 全部產出無錯誤
- E2E 17 cases 已寫齊（待 Phase 6 在 prod 跑驗收）
- Phase 3 整合測試結果：✅（code-graph test_gaps=18 經驗證為工具 false positive，已記於 docs/delivery/issue-3.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)