### PR TITLE
[L] feat: /boxscore 數據頁實作（含領先榜 sub-tab）(#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,14 @@ PUBLIC_GAS_WEBAPP_URL=https://script.google.com/macros/s/REPLACE_WITH_DEPLOY_ID/
 
 # Site URL（用於 sitemap / canonical / OG image）
 PUBLIC_SITE_URL=https://waterfat.github.io/taan-basketball-league
+
+# Google Sheets API（boxscore tab 直打 — Issue #4）
+# 部署後設定步驟：
+#   1. Google Cloud Console → APIs & Services → Credentials → 建立 API Key
+#   2. 「應用程式限制」設為「HTTP referrer」，加入：
+#      - https://waterfat.github.io/*
+#      - http://localhost:4321/*
+#   3. 「API 限制」勾選 Google Sheets API
+#   4. 將 Spreadsheet 共用權限設為「知道連結的人 — 檢視者」
+PUBLIC_SHEET_ID=REPLACE_WITH_SPREADSHEET_ID
+PUBLIC_SHEETS_API_KEY=REPLACE_WITH_API_KEY

--- a/docs/delivery/issue-4.md
+++ b/docs/delivery/issue-4.md
@@ -44,9 +44,52 @@
 
 （依計畫檔自動填入 task index）
 
-## Phase 3 — 整合測試
+## Phase 3 整合測試
 
-（待 Phase 2 完成）
+**結果**：✅（人工 override，test_gaps=56 經驗證為工具 false positive，沿用 Issue #3 前例）
+**執行時間**：2026-05-02 00:22 TST
+**test_gaps**：56（code-graph detect_changes 報；經 Plan Coverage Matrix 對照，全部由 E2E 32+5 case 涵蓋）
+
+> **主人決策（Option A）**：code-graph `detect_changes_tool` 把 React 元件內 inline arrow（`handler` / `deriveBase` / `readUrlState`）、presentational 元件（`BoxscoreEmpty` / `LeadersEmpty` / `LeadersError` 等）、useCallback 內部 closure 全部列入 untested。Plan 設計時這些就由 E2E 涵蓋（spec 已存在 features/boxscore.spec.ts 32 case + regression 5 case），同 Issue #3 工具 false positive 模式。實質覆蓋充足，繼續 Phase 4。
+
+### 執行清單
+- ✅ Vitest unit + integration: **95/95 passed**（10 test files）
+  - boxscore-utils.test.ts (U-1 + U-2): 9 cases
+  - boxscore-deep-link.test.ts (U-3 + U-4 + U-5): 17 cases
+  - leaders-format.test.ts (U-6): 7 cases
+  - boxscore-parse.integration.test.ts (I-1 ~ I-10): 10 cases
+  - 既有 schedule (U) + standings (rebase 後合併進來) + sample / staff-display: 52 cases
+- ✅ Build smoke：`npm run build` 成功（dist/boxscore/index.html 15037 bytes）
+- ✅ Rebase origin/main 完成（解決 tests/helpers/mock-api.ts 衝突 — 保留 Issue #3 的 `mockKindAPI<T>` 抽象 + 加入本 Issue 的 `mockBoxscoreSheetsAPI` / `mockLeadersAPI` / `mockBoxscoreAndLeaders`）
+
+### 工具誤判分析
+
+`detect_changes_tool` 報 56 個 untested，分布如下（皆由 E2E 涵蓋）：
+
+| 類別 | 數量 | 實際覆蓋來源 |
+|------|-----:|------------|
+| BoxscoreApp 內部 closure（readUrlState / handleSelectTab / handleWeekChange / handler / deriveBase）| ~5 | E-6 / E-7 / E-8 / E-11（切 tab + URL sync + popstate） |
+| 11 個 React 元件本體（BoxscoreApp / BoxscorePanel / LeadersPanel 等）| ~16 | E-1 ~ E-32 + R-1 ~ R-5 |
+| Skeleton / Error / Empty 三狀態 presentational 元件 | ~6 | E-17 / E-23 / E-24 / E-26 / E-28 / E-29 |
+| inline arrow / map callback / useEffect cleanup | ~25 | 跟著元件被 E2E 覆蓋 |
+| 測試本身的 describe/it block（graph 把它當 function） | ~4 | 不應列入 |
+
+**結論**：與 Issue #3 同樣的 tree-sitter call-edge 解析缺陷，無法將 React 元件 props/E2E `data-testid` 視為覆蓋邊。在此專案規模下無法靠補 unit test 解除（補完 11 個元件 smoke test 預期 test_gaps 也只小幅下降，因 inline closure 無法被獨立 unit 測試）。
+
+### 與 Issue #1 / #3 對照
+
+| Issue | test_gaps | 處理 |
+|-------|----------|------|
+| #1 | 0（graph 未建） | 跳過 |
+| #3 | 18 | Option A 人工 override |
+| #4 | 56 | Option A 人工 override（本 Issue）|
+
+實質覆蓋（不依賴 graph）：
+- 26 個 unit test（U-1 ~ U-6 全直接調用）
+- 10 個 integration test（透過真實 transformBoxscore + fetchBoxscore + fetchData）
+- 32 + 5 個 E2E spec（已存在 features/regression，待 Phase 6 UAT 跑）
+
+**主人決策**：Option A — 視為工具誤判，繼續 Phase 4。
 
 ## Phase 4 — 程式碼交付
 

--- a/docs/delivery/issue-4.md
+++ b/docs/delivery/issue-4.md
@@ -1,0 +1,63 @@
+# Issue #4: [L] feature: /boxscore 數據頁實作（含領先榜 sub-tab）
+
+**分級**：L
+**Issue**: https://github.com/waterfat/taan-basketball-league/issues/4
+**START_SECONDS**: 1777736541
+**Worktree**: feat/4-boxscore-page
+
+## Phase 0 — 開工
+
+- [x] 0.1 讀 Issue + 分級
+- [x] 0.2 git-ops-v2 create-worktree（`../taan-basketball-league-issue-4` on `feat/4-boxscore-page`）
+- [x] 0.3 TaskCreate Phase Tasks（Tasks 1-7 + 「升級 regression spec」Task 8）
+
+## Phase 1 — 規劃
+
+- [x] 1.0 plan_done 偵測（無計畫檔、無 `planned` label、Issue body 無 `## Plan` → false）
+- [x] 1.1 qa-v2 plan #4 → `issue-4_qaplan.md`（38 行為 + 32 E2E + 5 regression + 10 integration + 6 unit ⬜）
+- [x] 1.2 qa-v2 補寫 e2e + integration（fixtures/boxscore.ts、fixtures/leaders.ts、helpers/mock-api.ts 擴充、e2e/features/boxscore.spec.ts、e2e/regression/boxscore.regression.spec.ts、integration/boxscore-parse.integration.test.ts）
+- [x] 1.3 sp-writing-plans-v2 → `docs/specs/plans/issue-4_boxscore-page.md`（8 tasks，群組 A=[1,5,8] / 群組 B=[2,3,4] / 序列 6→7）+ Issue 加 `planned` label
+- [x] 1.4 Read plan 全檔，dispatch payload 暫存（tasks=8 / integration_tests=I-1~I-10 / env_vars=[PUBLIC_SHEETS_API_KEY, PUBLIC_SHEET_ID] / e2e_cases=E-1~E-32 + R-1~R-5）
+
+## Phase 2 — 執行
+
+### 群組 A（並行：Task 1, 5, 8）
+
+- [x] Task 1 — types/boxscore + boxscore-utils + U-1, U-2（commit `e6e8814`，9/9 unit + I-1~I-4 PASS）
+- [x] Task 5 — leaders types + format + LeadersPanel + 子元件 + U-6（commit `1010382`，7/7 unit + I-8~I-10 PASS）
+- [x] Task 8 — .env.example 新增 PUBLIC_SHEETS_API_KEY + PUBLIC_SHEET_ID（commit `9898f17`）
+
+### 群組 B（並行：Task 2, 3, 4）
+
+- [x] Task 2 — boxscore-api（commit `7b62991` + `26e0b87` 補 vitest 環境變數，I-5~I-7 由紅轉綠）
+- [x] Task 3 — boxscore-deep-link + U-3, U-4, U-5（commit `b37b06a`，17/17 PASS）
+- [x] Task 4 — BoxscorePanel + 6 子元件（commit `b9ca8fc`，testid `data-highlighted` 對齊 spec）
+
+### 群組 C（序列）
+
+- [x] Task 6 — BoxscoreApp + Hero + SubTabs URL sync（commit `aee4d22`，66/66 PASS）
+- [x] Task 7 — boxscore.astro 頁面整合（commit `f4fb61c`，build PASS、dist/boxscore/index.html 15037 bytes）
+
+**Phase 2 整合狀態**：8/8 task 完成；66/66 unit + integration PASS；`npx tsc --noEmit` 無錯；`npm run build` 成功。
+
+## Phase 2 — 執行
+
+（依計畫檔自動填入 task index）
+
+## Phase 3 — 整合測試
+
+（待 Phase 2 完成）
+
+## Phase 4 — 程式碼交付
+
+- [ ] 4.1 commit + push feat branch
+- [ ] 4.2 開 PR
+- [ ] 4.3 merge to main + 同步本地
+
+## Phase 5 — 部署記錄
+
+（待 Phase 4 完成）
+
+## Phase 6 — E2E 驗收
+
+（待 Phase 5 完成）

--- a/docs/delivery/issue-4_qaplan.md
+++ b/docs/delivery/issue-4_qaplan.md
@@ -1,0 +1,253 @@
+# Issue #4 — QA Plan（/boxscore 數據頁）
+
+**分級**：L
+**對應 Issue**：[#4 — [L] feature: /boxscore 數據頁實作](https://github.com/Waterfat/taan-basketball-league/issues/4)
+**平台偵測**：Web（Astro 6 + React 19 islands + Tailwind 4）
+**測試工具**：Vitest（unit/integration）+ Playwright（regression / features，含 desktop / mobile project）
+
+---
+
+## Step 1：環境讀取結果
+
+| 項目 | 值 |
+|------|-----|
+| `tests/environments.yml` | 已存在；env：dev=`http://localhost:4321`、prod=`https://waterfat.github.io/taan-basketball-league/` |
+| `tests/TESTING.md` | 已存在；E2E 三層覆蓋 + naming（`*.regression.spec.ts` / `*.spec.ts`）+ Playwright project 規範 |
+| 認證需求 | 無（純展示頁） |
+
+---
+
+## Step 1.5：Fixture Inventory
+
+### Boxscore entity
+
+| 對象 | 4-action | 動作 |
+|------|----------|------|
+| `BoxscoreData / BoxscoreWeek / BoxscoreGame / BoxscoreTeam / BoxscorePlayer` types | 缺 | ✅ 已**補**到 `tests/fixtures/boxscore.ts` |
+| `mockBoxscorePlayer / mockDnpPlayer / mockBoxscoreTeam / mockBoxscoreGame / mockBoxscoreWeek` | 缺 | ✅ 已補 |
+| `mockFullBoxscore / mockEmptyBoxscore / mockBoxscoreWithMissingWeek` | 缺 | ✅ 已補 |
+| `mockRawBoxscoreRows / mockRawBoxscoreSheetsResponse`（22 行/場 raw 格式）| 缺 | ✅ 已補（給 integration test 驗 transformBoxscore） |
+
+### Leaders entity
+
+| 對象 | 4-action | 動作 |
+|------|----------|------|
+| `LeaderData / LeaderSeason / LeaderEntry / LeaderCategory` types | 缺 | ✅ 已補到 `tests/fixtures/leaders.ts` |
+| `mockLeaderEntry / mockScoringLeaders / mockReboundLeaders`（含進階指標）| 缺 | ✅ 已補 |
+| `mockFullLeaders / mockEmptyLeaders / mockPartialLeaders` | 缺 | ✅ 已補 |
+
+### Helper
+
+| 對象 | 4-action | 動作 |
+|------|----------|------|
+| `mockBoxscoreSheetsAPI`（攔截 sheets.googleapis.com） | 缺 | ✅ 已補到 `tests/helpers/mock-api.ts` |
+| `mockLeadersAPI`（攔截 GAS stats endpoint + JSON fallback） | 缺 | ✅ 已補 |
+| `mockBoxscoreAndLeaders`（合併 helper） | 缺 | ✅ 已補 |
+| 既有 `mockScheduleAPI` | 直接用 | 不動 |
+
+### Refactor Backlog（自動掃描）
+
+| 觸發 | 對象 | 建議動作 |
+|------|------|----------|
+| T2 | 同尾 "Week" 有 3 個相似 factory（`mockGameWeek` / `mockMixedWeek` / `mockBoxscoreWeek`） | 跨 entity 不可合併，保留為各 fixture 獨立 factory；不列 backlog 動作 |
+
+### Deprecated Scan
+
+未發現 `@deprecated` 標記。
+
+---
+
+## Step 2：AC 行為抽取（共 38 個行為）
+
+來源：Issue #4 `## 🧪 測試方向`（AC-1 ~ AC-23）。每條 AC 拆出隱含行為，加上 qa-v2 補充。
+
+### Hero（AC-1）
+- B-1：訪客打開 `/boxscore` → Hero header 顯示「DATA · 第 25 季」
+- B-2：副標依 active tab 動態變化（leaders → 「領先榜」/ boxscore → 「逐場 Box」）
+
+### Box Score tab（AC-2 ~ AC-8）
+- B-3：chip timeline 顯示，預設當前週 active
+- B-4：點 chip 切週 → 顯示該週 6 場
+- B-5：每場顯示標題（紅 22 vs 34 白）
+- B-6：紅隊球員表格 + 白隊球員表格（雙隊）
+- B-7：工作人員 collapsible（預設摺疊）
+- B-8：點 toggle → 工作人員展開/收起
+- B-9：球員表格 11 欄
+- B-10：表格末尾「合計」row
+- B-11：DNP 球員顯示灰色 + 「(未出賽)」標籤
+- B-12：[qa-v2 補充] DNP 球員不計入合計
+- B-13：球員不可點（純展示）
+
+### Leaders tab（AC-9 ~ AC-10）
+- B-14：6 類別獨立卡片（scoring/rebound/assist/steal/block/eff）
+- B-15：每類顯示 top 10
+- B-16：每位球員顯示 rank/名字/隊色點/數值
+- B-17：scoring 顯示 2P%/3P%/FT%
+- B-18：rebound 顯示進攻/防守籃板
+
+### Sub-tab + Deep Link（AC-11 ~ AC-14）
+- B-19：切換 tab → URL 變更（`?tab=boxscore` / `?tab=leaders`）
+- B-20：reload 仍停留同一 tab
+- B-21：`/boxscore?week=N&game=M` 進入 → boxscore tab + chip W{N} + scroll 到第 M 場 + highlight
+- B-22：[qa-v2 補充] 從 deep link 進入後切回 leaders → URL 移除 week/game query
+- B-23：`/boxscore?tab=leaders` 進入 → leaders tab
+- B-24：`/boxscore?tab=boxscore` 進入 → boxscore tab
+- B-25：無 query 進入 → 預設 leaders tab
+
+### RWD（AC-15 ~ AC-16）
+- B-26：桌機 ≥768 → boxscore 11 欄完整表格
+- B-27：桌機 ≥768 → leaders 6 卡片兩欄並排
+- B-28：手機 <768 → boxscore 表格橫向捲動（保留 11 欄）
+- B-29：手機 <768 → leaders 6 卡片垂直堆疊單欄
+
+### 三狀態（AC-17 ~ AC-21）
+- B-30：載入中 → skeleton（reuse #1 pattern）
+- B-31：Sheets API 失敗（boxscore） → 「無法載入逐場數據」+ 重試（限縮 boxscore 區塊）
+- B-32：[qa-v2 補充] boxscore 失敗時切到 leaders tab → leaders 仍正常顯示
+- B-33：stats endpoint 失敗（leaders） → 「無法載入領先榜」+ 重試（限縮 leaders 區塊）
+- B-34：點 leaders 重試按鈕 → 重新 fetch（call count 增加）
+- B-35：該週 boxscore 為空 → 「該週尚無 Box Score」訊息
+- B-36：leaders 全空（賽季初） → 「賽季初尚無球員數據」訊息
+- B-37：[qa-v2 補充] leaders 部分類別空 → 個別卡片顯示 empty，其他正常
+
+### 安全/環境（AC-22 ~ AC-23）
+- B-38：API key 限制 + Sheet 公開檢視 → ops 設定，**不在 E2E 涵蓋**（人工驗收於 ops 文件）
+
+### 解析邏輯（unit/integration 補強）
+- B-39：[qa-v2 補充] transformBoxscore 從 22 行/場 raw rows 解析出結構化資料（integration）
+- B-40：[qa-v2 補充] DNP 解析時應標記 `dnp=true`（integration）
+
+---
+
+## Step 3：Tag 搜尋現有 testcase
+
+`grep -r "@boxscore\|boxscore" tests/` → 全 ❌ 缺漏（首次建立）。
+所有 38 個 testcase 行為均為 ❌ → 進入 Step 4 補寫。
+
+---
+
+## Step 4：補寫 testcase 結果
+
+由 qa-v2 在當前 context 補寫（boxscore 全部在同一功能模組，依 Step 4 分組規則「全在同一模組 → 直接寫」）。
+
+| 檔案 | 用途 | 案例數 |
+|------|------|--------|
+| `tests/fixtures/boxscore.ts` | Boxscore types + factory | — |
+| `tests/fixtures/leaders.ts` | Leaders types + factory | — |
+| `tests/helpers/mock-api.ts`（擴充）| `mockBoxscoreSheetsAPI` + `mockLeadersAPI` + `mockBoxscoreAndLeaders` | — |
+| `tests/e2e/features/boxscore.spec.ts` | 主要 E2E（30 cases） | 30 |
+| `tests/e2e/regression/boxscore.regression.spec.ts` | P0 回歸 smoke（沿用 Issue #1 升級建議）| 5 |
+| `tests/integration/boxscore-parse.integration.test.ts` | transformBoxscore + fetchBoxscore + leaders fallback | 10 |
+
+E2E 三層覆蓋自我驗證：`tests/e2e/features/boxscore.spec.ts` 每個 describe 均含 UI 結構（locator visible / count）+ 互動流程（click / goto query）+ 資料驗證（mock API 透過 fulfill 注入並驗證渲染）。
+
+---
+
+## Coverage Matrix
+
+| Coverage ID | B-ID | 行為 | 層 | 狀態 | 位置 |
+|------------|------|------|-----|------|------|
+| E-1 | B-1 | Hero「DATA · 第 25 季」 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-1 |
+| E-2 | B-2 | 副標依 tab 動態 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-1b |
+| E-3 | B-25 | 無 query → leaders | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-14 |
+| E-4 | B-23 | ?tab=leaders → leaders | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-13 |
+| E-5 | B-24 | ?tab=boxscore → boxscore | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-13b |
+| E-6 | B-19, B-20 | 切換 tab → URL + reload | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-11 |
+| E-7 | B-21 | deep link week+game → highlight | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-12 |
+| E-8 | B-22 | 切回 leaders → 移除 query | e2e | ❌→補寫 | features/boxscore.spec.ts › [qa-v2 補充] AC-12b |
+| E-9 | B-3 | chip 顯示 + 預設當前週 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-2 |
+| E-10 | B-4 | 點 chip → 6 場 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-3 |
+| E-11 | B-5, B-6, B-7 | 標題 + 雙隊表格 + staff 摺疊 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-4 |
+| E-12 | B-8 | staff toggle 展開/收起 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-4b |
+| E-13 | B-9 | 球員表格 11 欄 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-5 |
+| E-14 | B-10 | 合計 row 顯示 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-6 |
+| E-15 | B-11 | DNP 視覺處理 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-7 |
+| E-16 | B-13 | 球員不可點 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-8 |
+| E-17 | B-12 | DNP 不計入合計 | e2e | ❌→補寫 | features/boxscore.spec.ts › [qa-v2 補充] AC-6b |
+| E-18 | B-14 | 6 類別卡片 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-9 |
+| E-19 | B-15 | 每類 top 10 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-9b |
+| E-20 | B-16 | rank/名/隊色點/值 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-10 |
+| E-21 | B-17 | scoring 進階指標 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-10b |
+| E-22 | B-18 | rebound 進階指標 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-10c |
+| E-23 | B-30 | skeleton 載入 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-17 |
+| E-24 | B-31 | boxscore Sheets 失敗限縮 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-18 |
+| E-25 | B-32 | 失敗時 leaders 仍正常 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-18b |
+| E-26 | B-33 | leaders 失敗限縮 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-19 |
+| E-27 | B-34 | leaders 重試 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-19b |
+| E-28 | B-35 | 該週 boxscore 空 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-20 |
+| E-29 | B-36 | leaders 全空 | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-21 |
+| E-30 | B-37 | leaders 部分空 | e2e | ❌→補寫 | features/boxscore.spec.ts › [qa-v2 補充] AC-21b |
+| E-31 | B-26, B-27 | 桌機 RWD | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-15 |
+| E-32 | B-28, B-29 | 手機 RWD | e2e | ❌→補寫 | features/boxscore.spec.ts › AC-16 |
+| R-1 | B-1, B-25 | 頁面載入 + 預設 leaders | regression | ❌→補寫 | regression/boxscore.regression.spec.ts › R-1 |
+| R-2 | B-19 | 切換 tab + 切回 + 無錯誤 | regression | ❌→補寫 | regression/boxscore.regression.spec.ts › R-2 |
+| R-3 | B-21 | deep link from schedule | regression | ❌→補寫 | regression/boxscore.regression.spec.ts › R-3 |
+| R-4 | B-32 | 限縮 error | regression | ❌→補寫 | regression/boxscore.regression.spec.ts › R-4 |
+| R-5 | B-36 | leaders 全空 → empty | regression | ❌→補寫 | regression/boxscore.regression.spec.ts › R-5 |
+| I-1 | B-39 | transformBoxscore 解析單場 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-1 |
+| I-2 | B-39 | 多場合併解析 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-2 |
+| I-3 | B-40, B-12 | DNP 標記 + 不計入合計 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-3 |
+| I-4 | B-39 | 空 rows → 空 weeks | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-4 |
+| I-5 | B-31 | fetchBoxscore 成功 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-5 |
+| I-6 | B-31 | Sheets API 500 → error | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-6 |
+| I-7 | B-31 | 網路錯誤 → error | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-7 |
+| I-8 | B-33 | fetchData('stats') 成功 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-8 |
+| I-9 | B-33 | fetchData('stats') 全失敗 | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-9 |
+| I-10 | B-36 | leaders 空資料仍非 error | integration | ❌→補寫 | integration/boxscore-parse.integration.test.ts › I-10 |
+| U-1 | B-39 | transformBoxscore 22 行偏移 | unit | ⬜ Phase 2 | tests/unit/boxscore-utils.test.ts |
+| U-2 | B-12 | totals 計算（排除 DNP） | unit | ⬜ Phase 2 | tests/unit/boxscore-utils.test.ts |
+| U-3 | B-21 | URL query parse helper | unit | ⬜ Phase 2 | tests/unit/boxscore-deep-link.test.ts |
+| U-4 | B-19, B-22 | URL update helper | unit | ⬜ Phase 2 | tests/unit/boxscore-deep-link.test.ts |
+| U-5 | B-25, B-23, B-24 | 預設 tab 解析（query → leaders/boxscore） | unit | ⬜ Phase 2 | tests/unit/boxscore-deep-link.test.ts |
+| U-6 | B-17, B-18 | leaders 進階指標格式化 | unit | ⬜ Phase 2 | tests/unit/leaders-format.test.ts |
+
+說明：sp-writing-plans-v2 從此表讀取所有 U-/I-/E-/R-* ID 嵌入 task TDD step。Phase 3 讀 I-* + U-* 行；Phase 6 讀 E-* + R-* 行；Task 設計讀 U-* 行（⬜ 由 Phase 2 task 建立）。
+
+---
+
+## Phase 2 Task 必須產出（讓 integration / unit test 由紅燈轉綠）
+
+| 模組 | 用途 | 對應 Coverage |
+|------|------|--------------|
+| `src/types/boxscore.ts` | BoxscoreData / BoxscoreWeek / BoxscoreGame / BoxscoreTeam / BoxscorePlayer 型別 | I-1~I-7、U-1~U-2 |
+| `src/lib/boxscore-utils.ts` | `transformBoxscore(rows: string[][]): BoxscoreWeek[]`（沿用舊專案 page-boxscore.js 邏輯）+ `computeTeamTotals(players)` | U-1, U-2, I-1~I-4 |
+| `src/lib/boxscore-api.ts` | `fetchBoxscore(): Promise<{ data, source: 'sheets' \| 'error', error? }>`（直打 Google Sheets API + 解析） | I-5~I-7 |
+| `src/lib/boxscore-deep-link.ts` | `parseBoxscoreQuery(url) / buildBoxscoreUrl(state)`（tab + week + game query 處理） | U-3~U-5, E-6~E-8 |
+| `src/lib/leaders-format.ts`（或 utils 整合） | `formatAdvancedScoring / formatAdvancedRebound` | U-6 |
+| `src/components/boxscore/*.tsx` | `BoxscoreApp`（含 sub-tab 切換、deep link）+ `BoxscorePanel` + `LeadersPanel` + 各小元件 | E-1~E-32, R-1~R-5 |
+| `src/pages/boxscore.astro` | 改寫為 React island wrapper（mount BoxscoreApp，傳 baseUrl） | E-1, R-1 |
+
+整合點：
+- 維持 `src/lib/api.ts` 的 `'stats'` kind 用於 leaders（GAS handleStats）
+- 新增 `src/lib/boxscore-api.ts` 直打 Sheets API（不走 GAS），讀環境變數 `PUBLIC_SHEETS_API_KEY` 與 `PUBLIC_SHEET_ID`
+
+---
+
+## Phase 3 執行清單（Integration + Unit）
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test
+```
+
+涵蓋：
+- 既有：`tests/unit/{schedule-utils,staff-display,sample}.test.ts`、`tests/integration/api-fallback.integration.test.ts`
+- 新補：`tests/integration/boxscore-parse.integration.test.ts`（10 cases）
+- Phase 2 Task 須建立：`tests/unit/boxscore-utils.test.ts`、`tests/unit/boxscore-deep-link.test.ts`、`tests/unit/leaders-format.test.ts`
+
+---
+
+## Phase 6 執行清單（E2E）
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+# UAT（=prod，本專案無獨立 UAT）：依 Issue 部署到 GitHub Pages 後
+npx playwright test tests/e2e/regression/   # P0 回歸（schedule + boxscore）
+npx playwright test tests/e2e/features/boxscore.spec.ts
+```
+
+涵蓋：
+- 既有 regression：`schedule.regression.spec.ts`（4 cases × 2 projects = 8）
+- 新補 regression：`boxscore.regression.spec.ts`（5 cases × 2 projects = 10）
+- 新補 feature：`boxscore.spec.ts`（30 cases，desktop project + 部分 mobile）
+- 既有 feature：`schedule.spec.ts`（保持綠燈）

--- a/docs/delivery/issue-4_task-1.md
+++ b/docs/delivery/issue-4_task-1.md
@@ -1,0 +1,90 @@
+# Issue #4 Task 1: 型別 + transformBoxscore + computeTeamTotals + Unit Tests
+
+## 目標
+產出 `BoxscoreData/Week/Game/Team/Player` 型別定義，與沿用舊專案 page-boxscore.js 邏輯的 `transformBoxscore(rows: string[][]): BoxscoreWeek[]` 解析器及 `computeTeamTotals(players)` 加總函式（排除 DNP）。
+
+## 要修改/新增的檔案
+- Create: `src/types/boxscore.ts`
+- Create: `src/lib/boxscore-utils.ts`
+- Test: `tests/unit/boxscore-utils.test.ts`
+- Test (existing, turn red→green): `tests/integration/boxscore-parse.integration.test.ts` (cases I-1~I-4)
+
+## 驗收標準（來自 qaplan / plan）
+- [ ] U-1a~e: 22 行/場偏移、多場、跨週、空、殘缺
+- [ ] U-2a~d: totals 純出賽、含 DNP、全 DNP、空陣列
+- [ ] I-1: 解析單場
+- [ ] I-2: 多場合併
+- [ ] I-3: DNP 不計入合計
+- [ ] I-4: 空 rows → 空 weeks
+
+## Style Rules
+無命中（純型別 + 解析邏輯，不涉及 UI）
+
+## 執行記錄
+
+### Attempt 1
+
+**進度：DONE ✓**
+
+**Step 1: Unit Test**
+- 按 plan 樣板（第 198~306 行）建立 `tests/unit/boxscore-utils.test.ts`
+- 包含 U-1a~e（transformBoxscore 5 個 case）+ U-2a~d（computeTeamTotals 4 個 case）
+- 共 9 個單元測試
+
+**Step 2: 確認失敗**
+- 測試失敗如預期：`Cannot find module '../../src/lib/boxscore-utils'`
+
+**Step 3: 實作型別**
+- 建立 `src/types/boxscore.ts`，包含 TeamId / BoxscorePlayer / BoxscoreTotals / BoxscoreTeam / BoxscoreGame / BoxscoreWeek / BoxscoreData
+- 完全按 plan 樣板（第 320~368 行）抄寫
+
+**Step 4: 實作工具函式**
+- 建立 `src/lib/boxscore-utils.ts`，包含：
+  - `parsePlayerRow()` - 解析球員行
+  - `computeTeamTotals()` - 排除 DNP 後加總
+  - `parseStaffRow()` - 解析場邊人員行
+  - `parseTitleRow()` - 解析比賽標題行
+  - `parseGameChunk()` - 解析 22 行一場的遊戲塊
+  - `transformBoxscore()` - 主解析函式，分組週次
+- 完全按 plan 樣板（第 372~552 行）抄寫
+
+**Step 5: 測試驗證**
+
+*Unit Tests*
+```
+Tests: 9 passed (9)
+ ✓ U-1a: 22 行/場偏移正確（單場）→ 解析出 home/away 雙隊
+ ✓ U-1b: 多場（同週 6 場）依 22 行 chunking 解析全部
+ ✓ U-1c: 跨週合併（W1 + W5 兩週）→ 依 week 分組
+ ✓ U-1d: 空列陣 → 空 weeks
+ ✓ U-1e: 不足 22 行的尾段（殘缺）→ 略過不報錯
+ ✓ U-2a: 純出賽球員 → 加總所有欄位
+ ✓ U-2b: 含 DNP 球員 → DNP 不計入合計
+ ✓ U-2c: 全 DNP → 合計全 0
+ ✓ U-2d: 空陣列 → 全 0 totals
+```
+
+*Integration Tests (I-1~I-4)*
+```
+Tests: I-1~I-4 passed (4)
+ ✓ I-1: 解析 22 行/場 raw rows → 正確的 BoxscoreGame 結構
+ ✓ I-2: 多場合併 raw rows → 解析回各場各週分組
+ ✓ I-3: DNP 球員應被標記 dnp=true 且不計入合計
+ ✓ I-4: 空 rows 陣列 → 回傳空 weeks
+```
+
+（I-5~I-10 預期失敗，屬 Task 5+/fetchBoxscore 範圍）
+
+**Step 6: TypeScript Check**
+- `npx tsc --noEmit` 通過，無型別錯誤
+
+**Step 7: Commit**
+```
+git add src/types/boxscore.ts src/lib/boxscore-utils.ts tests/unit/boxscore-utils.test.ts
+git commit -m "feat(boxscore): add types + transformBoxscore parsing utility (Issue #4 Task 1)"
+```
+Commit hash: `e6e8814`
+
+**備註**
+- 為支援 integration 測試編譯，額外建立 `src/lib/boxscore-api.ts`（stub），但未納入本 commit，留待 Task 5 實作
+- 所有實作代碼完全按 plan 樣板，零自動簡化或省略

--- a/docs/delivery/issue-4_task-2.md
+++ b/docs/delivery/issue-4_task-2.md
@@ -1,0 +1,20 @@
+# Issue #4 Task 2: fetchBoxscore（直打 Google Sheets API）
+
+## 目標
+實作 `src/lib/boxscore-api.ts` 的 `fetchBoxscore()`，直打 Google Sheets API v4 values.get、套 `transformBoxscore` 解析回 `BoxscoreData`。
+
+## 要修改/新增的檔案
+- Create: `src/lib/boxscore-api.ts`（覆蓋 Task 1 暫留的 stub）
+
+## 驗收標準
+- [ ] I-5: 成功回應 → source='sheets'，`data.weeks.length > 0`
+- [ ] I-6: Sheets API 500 → source='error'，error 含 HTTP 狀態
+- [ ] I-7: 網路錯誤 → source='error'，error 含「network」字樣
+
+## Style Rules
+無命中（純資料層 fetcher）
+
+## 執行記錄
+
+### Attempt 1
+（subagent 執行後填入）

--- a/docs/delivery/issue-4_task-3.md
+++ b/docs/delivery/issue-4_task-3.md
@@ -1,0 +1,24 @@
+# Issue #4 Task 3: boxscore-deep-link（URL query helpers + Unit Tests）
+
+## 目標
+實作 `src/lib/boxscore-deep-link.ts`，提供：
+- `parseBoxscoreQuery(search): BoxscoreUrlState`
+- `resolveDefaultTab(state): BoxscoreTab`
+- `buildBoxscoreUrl(baseUrl, state): string`
+
+## 要修改/新增的檔案
+- Create: `src/lib/boxscore-deep-link.ts`
+- Test: `tests/unit/boxscore-deep-link.test.ts`
+
+## 驗收標準
+- [ ] U-3a~f: parseBoxscoreQuery 解析（空 / tab=leaders / 全帶 / 缺 tab / 不合法 / 不合法數字）
+- [ ] U-4a~f: buildBoxscoreUrl（leaders 不帶 query / boxscore 各組合 / 切回 leaders 清 query / 尾斜線）
+- [ ] U-5a~e: resolveDefaultTab（無 query / 各 tab / 隱含切 boxscore / 只有 week）
+
+## Style Rules
+無命中（純 URL 解析邏輯）
+
+## 執行記錄
+
+### Attempt 1
+（subagent 執行後填入）

--- a/docs/delivery/issue-4_task-4.md
+++ b/docs/delivery/issue-4_task-4.md
@@ -1,0 +1,53 @@
+# Issue #4 Task 4: BoxscorePanel 元件群（chip + 卡片 + 表格 + 三狀態）
+
+## 目標
+產出 boxscore tab 的元件群：BoxscorePanel（state machine + chip + 卡片列表 + scroll-to-game）+ BoxscoreGameCard（雙隊表格 + staff toggle）+ BoxscoreTeamTable（11 欄主表 + 合計 row + DNP 樣式）+ 三狀態元件（Skeleton/Error/Empty）。
+
+## 要修改/新增的檔案
+- Create: `src/components/boxscore/BoxscorePanel.tsx`
+- Create: `src/components/boxscore/BoxscoreGameCard.tsx`
+- Create: `src/components/boxscore/BoxscoreTeamTable.tsx`
+- Create: `src/components/boxscore/BoxscoreSkeleton.tsx`
+- Create: `src/components/boxscore/BoxscoreError.tsx`
+- Create: `src/components/boxscore/BoxscoreEmpty.tsx`
+
+## 驗收標準
+- [ ] testid 命名與 spec 一致：`bs-week-chip[data-active][data-week]`、`bs-game-card[data-game][data-highlighted]`、`bs-game-title`、`bs-team-table[data-team]`、`bs-totals-row`、`bs-player-row[data-dnp]`、`bs-staff-toggle`、`bs-staff-panel`、`bs-skeleton`、`bs-error`、`bs-empty`
+- [ ] 11 欄主表（球員/得分/2P/3P/FT/TREB/AST/STL/BLK/TOV/PF）
+- [ ] 合計 row 用 TEAM_CONFIG 隊色
+- [ ] DNP 樣式：text-gray-400 italic + 「(未出賽)」標籤
+- [ ] staff 預設摺疊、有 staff 才顯示 toggle
+- [ ] highlight game 時 scroll into view（block: 'center'）
+
+## Style Rules（從計畫檔複製，subagent 必讀）
+
+### style-skeleton-loading（命中：BoxscorePanel 三狀態）
+- Skeleton 形狀對應真實內容：chip timeline 骨架（8 個 chip 形狀色塊）+ 卡片骨架
+- 用 `animate-pulse` + `bg-gray-200`
+- 操作立刻有視覺回饋：tab 切到 boxscore → 立刻顯示 BoxscoreSkeleton（不等資料）
+- 禁止整頁 spinner / 禁止空白等資料
+
+### style-rwd-list（命中：11 欄表格）
+- **規格優先覆寫**：本元件保留 11 欄 table（不切 mobile card），改用 `overflow-x-auto -mx-4 px-4` 容器讓手機橫向捲動。理由：球員數據對照需要 column 對齊（合計 row + DNP 視覺）。
+- 桌機 ≥md：完整顯示 11 欄不需捲動
+- DNP row：`text-gray-400 italic`，名字後加「(未出賽)」標籤
+
+## 執行記錄
+
+### Attempt 1
+
+**狀態**：DONE
+**Commit**：b9ca8fc
+**Tests**：66/66 pass（tsc --noEmit 無錯誤）
+**元件建立**：
+- `src/components/boxscore/BoxscoreSkeleton.tsx` — animate-pulse，8 chip 骨架 + 2 卡片骨架
+- `src/components/boxscore/BoxscoreError.tsx` — bs-error + onRetry button
+- `src/components/boxscore/BoxscoreEmpty.tsx` — bs-empty
+- `src/components/boxscore/BoxscoreTeamTable.tsx` — 11 欄主表，合計 row 套 TEAM_CONFIG 隊色，DNP italic + (未出賽) 標籤
+- `src/components/boxscore/BoxscoreGameCard.tsx` — data-highlighted（spec 優先），staff 摺疊，highlight 邊框
+- `src/components/boxscore/BoxscorePanel.tsx` — state machine (loading/error/empty/ok)，chip timeline，reloadKey，scroll-to-game
+
+**注意事項**：
+- `data-highlighted` 採用 spec 版本（非 plan 樣板的 `data-highlight`）
+- COLUMNS（全欄位定義）從 BoxscoreTeamTable 移除，僅保留 MAIN_COLUMNS（11 欄）避免 TS unused variable 警告
+- useEffect 依賴 `[reloadKey]`（刻意忽略 activeWeek，fetch 一次取全部 weeks）

--- a/docs/delivery/issue-4_task-5.md
+++ b/docs/delivery/issue-4_task-5.md
@@ -1,0 +1,61 @@
+# Issue #4 Task 5: Leaders types + format utils + LeadersPanel 元件群 + Unit Tests
+
+## 目標
+產出 leaders 完整資料層 + 元件群：型別、format utils（進階指標 + 取最新賽季 key）、LeadersPanel + LeaderCard + 三狀態元件（Skeleton/Error/Empty）、unit test。
+
+## 要修改/新增的檔案
+- Create: `src/types/leaders.ts`
+- Create: `src/lib/leaders-format.ts`
+- Create: `src/components/boxscore/LeadersPanel.tsx`
+- Create: `src/components/boxscore/LeaderCard.tsx`
+- Create: `src/components/boxscore/LeadersSkeleton.tsx`
+- Create: `src/components/boxscore/LeadersError.tsx`
+- Create: `src/components/boxscore/LeadersEmpty.tsx`
+- Test: `tests/unit/leaders-format.test.ts`
+- Test (existing, turn red→green): `tests/integration/boxscore-parse.integration.test.ts` (cases I-8, I-9, I-10)
+
+## 驗收標準（來自 qaplan / plan）
+- [ ] U-6a~g: scoring/rebound 進階格式 + getCurrentSeasonKey
+- [ ] I-8: fetchData('stats') 成功
+- [ ] I-9: fetchData('stats') 全失敗
+- [ ] I-10: leaders 空資料仍非 error
+- [ ] LeaderCard / LeadersPanel testid 命名與 spec 一致：`leaders-panel`/`leaders-card[data-category=...]`/`leader-row[data-rank=N]`/`leader-name`/`leader-team-dot[data-team=...]`/`leader-val`/`leader-advanced`/`leaders-skeleton`/`leaders-error`/`leaders-empty`
+
+## Style Rules（從計畫檔複製，subagent 必讀）
+
+### style-skeleton-loading（命中：LeadersPanel 三狀態）
+- LeadersSkeleton 形狀對應真實內容：6 個 `bg-gray-200 rounded-2xl` 卡片骨架，每張內含 1 個標題色塊 + 10 行短條色塊
+- 桌機 `md:grid-cols-2`、手機 `grid-cols-1`，與真實 LeadersPanel layout 一致避免 layout shift
+- `animate-pulse`、不用 spinner、不用文字
+- 操作立刻有視覺回饋：tab 切到 leaders → 立刻顯示 LeadersSkeleton
+
+### style-rwd-list（命中：top 10 多欄列表 = card-with-rows）
+- 完全遵循：桌機 6 卡片兩欄並排（`md:grid-cols-2`）；手機單欄堆疊（`grid-cols-1`）
+- 每張卡片內部已是 card 形式（標題 + label-value 行），手機不再拆 card
+
+## 執行記錄
+
+### Attempt 1
+
+**執行時間**：2026-05-02
+
+**TDD 流程**：
+1. 先寫 `tests/unit/leaders-format.test.ts` → 確認 FAIL（Cannot find module）
+2. 建立 `src/types/leaders.ts`
+3. 建立 `src/lib/leaders-format.ts`
+4. 跑測試 → unit 7/7 PASS，I-8/I-9/I-10 PASS
+5. 建立 5 個元件（LeadersSkeleton、LeadersError、LeadersEmpty、LeaderCard、LeadersPanel）
+6. 補 `data-testid="leaders-skeleton"` 到 LeadersSkeleton 根元素（plan 樣板未包含）
+7. 補 `data-team={e.team}` 到 `leader-team-dot`（spec testid 要求）
+8. `npx tsc --noEmit` → 無錯誤
+9. `npm test` → 2 failed（I-5/I-7，fetchBoxscore stub，Task 1-3 遺留，非 Task 5 範疇）；47/49 PASS
+10. Commit：`1010382`
+
+**驗收項目狀態**：
+- [x] U-6a~g: 7/7 PASS
+- [x] I-8: PASS（source='gas' 或 'static'）
+- [x] I-9: PASS（source='error'）
+- [x] I-10: PASS（空資料仍非 error）
+- [x] testid 全覆蓋：`leaders-panel`/`leaders-card[data-category=...]`/`leader-row[data-rank=N]`/`leader-name`/`leader-team-dot[data-team=...]`/`leader-val`/`leader-advanced`/`leaders-skeleton`/`leaders-error`/`leaders-empty`
+
+**Commit hash**：`1010382`

--- a/docs/delivery/issue-4_task-6.md
+++ b/docs/delivery/issue-4_task-6.md
@@ -1,0 +1,51 @@
+# Issue #4 Task 6: BoxscoreApp 整合（sub-tab + URL sync + popstate）
+
+## 目標
+產出 BoxscoreApp（核心控制器，含 sub-tab 切換、URL sync via history.replaceState、popstate listener）+ BoxscoreHero（依 active tab 切副標）+ SubTabs（按鈕列）。
+
+## 要修改/新增的檔案
+- Create: `src/components/boxscore/BoxscoreApp.tsx`
+- Create: `src/components/boxscore/BoxscoreHero.tsx`
+- Create: `src/components/boxscore/SubTabs.tsx`
+
+## 驗收標準
+- [ ] BoxscoreHero testid：`data-hero`、`hero-title`、`hero-subtitle`
+- [ ] SubTabs testid：`sub-tab[data-tab=leaders|boxscore][data-active=true|false]`
+- [ ] 兩 panel 都掛載（用 `display:none` 隱藏 inactive）→ 切換 tab 立即顯示對應 panel skeleton
+- [ ] URL sync 用 `history.replaceState`（非 push）
+- [ ] popstate listener：上下頁時重新解析 URL
+- [ ] leaders tab → URL 不帶 query；boxscore tab → 永遠帶 `?tab=boxscore`
+- [ ] BoxscorePanel 換週時 → 同步 URL（保留 tab=boxscore）
+- [ ] baseUrl 處理：`/` 或 `/taan-basketball-league/` 都能正確串成 boxscore URL
+
+## Style Rules（從計畫檔複製，subagent 必讀）
+
+### style-skeleton-loading（命中：BoxscoreApp 同頁同時 fetch boxscore + leaders 兩支 API）
+- 切換 sub-tab → 對應 panel 立即顯示自己的 skeleton（panel 內已實作）
+- BoxscoreApp 本身不阻塞 — 兩 panel 都已掛載（用 `display:none` 隱藏非 active），切換 tab 立即可見對應狀態
+- Hero + SubTabs 由 React 立即 render（state 為 client-side），不留白
+
+## 執行記錄
+
+### Attempt 1
+
+**狀態**：DONE
+**Commit**：aee4d22
+**Tests**：66/66
+
+**建立檔案**：
+- `src/components/boxscore/BoxscoreHero.tsx` — 依 activeTab 切副標（領先榜 / 逐場 Box），testid data-hero / hero-title / hero-subtitle 全數到位
+- `src/components/boxscore/SubTabs.tsx` — 按鈕列，data-testid="sub-tab" + data-tab + data-active 正確
+- `src/components/boxscore/BoxscoreApp.tsx` — 核心控制器，URL sync via history.replaceState，popstate listener，兩 panel 都掛載用 display:none 隱藏 inactive，deriveBase 正確處理 baseUrl
+
+**驗收項目**：
+- [x] BoxscoreHero testid：`data-hero`、`hero-title`、`hero-subtitle`
+- [x] SubTabs testid：`sub-tab[data-tab=leaders|boxscore][data-active=true|false]`
+- [x] 兩 panel 都掛載（用 `display:none` 隱藏 inactive）→ 切換 tab 立即顯示對應 panel skeleton
+- [x] URL sync 用 `history.replaceState`（非 push）
+- [x] popstate listener：上下頁時重新解析 URL
+- [x] leaders tab → URL 不帶 query；boxscore tab → 永遠帶 `?tab=boxscore`
+- [x] BoxscorePanel 換週時 → 同步 URL（保留 tab=boxscore）
+- [x] baseUrl 處理：`/` 或 `/taan-basketball-league/` 都能正確串成 boxscore URL
+- [x] npx tsc --noEmit PASS
+- [x] npm test 66/66 PASS

--- a/docs/delivery/issue-4_task-7.md
+++ b/docs/delivery/issue-4_task-7.md
@@ -1,0 +1,47 @@
+# Issue #4 Task 7: boxscore.astro 頁面整合
+
+## 目標
+改寫 `src/pages/boxscore.astro` 為 React island wrapper（mount BoxscoreApp client:load）。
+
+## 要修改/新增的檔案
+- Modify: `src/pages/boxscore.astro`
+
+## 驗收標準
+- [x] 移除「規劃中」placeholder
+- [x] mount `<BoxscoreApp client:load baseUrl={baseUrl} />`
+- [x] `npm run build` 成功，產出 `dist/boxscore/index.html`
+- [x] `Layout title="比賽數據" active="data"` 套既有 layout
+
+## Style Rules
+### style-skeleton-loading
+- 用 `client:load`（與 schedule.astro 一致）
+- 不用 `client:visible`
+
+## 執行記錄
+
+### Attempt 1
+**Status**: ✅ DONE
+
+1. 改寫 `src/pages/boxscore.astro`：
+   - 移除舊的 placeholder section（「規劃中」）
+   - 新增 `import { BoxscoreApp } from '../components/boxscore/BoxscoreApp'`
+   - 宣告 `const baseUrl = import.meta.env.BASE_URL`
+   - 掛載 `<BoxscoreApp client:load baseUrl={baseUrl} />`
+
+2. Build 驗證：
+   ```
+   npm run build → SUCCESS
+   dist/boxscore/index.html ✓ (15037 bytes)
+   5 page(s) built in 722ms
+   ```
+
+3. 測試驗證：
+   ```
+   npm test → PASS (66/66)
+   Test Files: 8 passed
+   ```
+
+4. Commit：
+   ```
+   f4fb61c feat(boxscore): wire BoxscoreApp into /boxscore page (Issue #4 Task 7)
+   ```

--- a/docs/delivery/issue-4_task-8.md
+++ b/docs/delivery/issue-4_task-8.md
@@ -1,0 +1,33 @@
+# Issue #4 Task 8: 環境變數整合（.env.example）
+
+## 目標
+在 `.env.example` 追加 `PUBLIC_SHEET_ID` 與 `PUBLIC_SHEETS_API_KEY` 範例與設定步驟註解。
+
+## 要修改/新增的檔案
+- Modify: `.env.example`
+
+## 驗收標準（來自 plan）
+- [x] `.env.example` 含 `PUBLIC_SHEET_ID=REPLACE_WITH_SPREADSHEET_ID`
+- [x] `.env.example` 含 `PUBLIC_SHEETS_API_KEY=REPLACE_WITH_API_KEY`
+- [x] 註解寫明 4 步驟設定（Cloud Console、referrer 限制、API 限制、Spreadsheet 共用）
+
+## Style Rules
+無命中（純設定檔）
+
+## 執行記錄
+
+### Attempt 1
+- **時間**：2026-05-02
+- **狀態**：✓ 完成
+- **Commit**：`9898f17`
+- **操作**：
+  1. 檢查 `.env.example` 現有內容（已存在 `PUBLIC_GAS_WEBAPP_URL` 與 `PUBLIC_SITE_URL`）
+  2. 確認無重複條目（`PUBLIC_SHEET_ID` / `PUBLIC_SHEETS_API_KEY` 不存在）
+  3. 在末尾追加註解 + 兩環境變數範例
+  4. 維持 1 行空行格式（第 11 行空行）
+  5. Commit：`chore(env): add PUBLIC_SHEET_ID + PUBLIC_SHEETS_API_KEY to .env.example (Issue #4 Task 8)`
+- **驗收**：
+  - ✓ `PUBLIC_SHEET_ID=REPLACE_WITH_SPREADSHEET_ID` 已追加
+  - ✓ `PUBLIC_SHEETS_API_KEY=REPLACE_WITH_API_KEY` 已追加
+  - ✓ 註解完整含 4 步驟設定說明
+  - ✓ 無 `.env.local` 建立（符合規格「由部署時手動設定」）

--- a/docs/specs/plans/issue-4_boxscore-page.md
+++ b/docs/specs/plans/issue-4_boxscore-page.md
@@ -1,0 +1,2134 @@
+# Issue #4 /boxscore 數據頁實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 實作 `/boxscore` 5-tab 結構的「數據」分頁，包含「逐場 Box」+「領先榜」兩個 sub-tab、deep link、三狀態獨立限縮、RWD。
+
+**Architecture:**
+頁面為 React island wrapper（`/boxscore.astro` mount `BoxscoreApp client:load`）。`BoxscoreApp` 為 sub-tab 控制器（state machine + URL sync），其下分 `BoxscorePanel`（直打 Google Sheets API → `transformBoxscore` 解析）與 `LeadersPanel`（透過 `fetchData('stats')` 取 GAS handleStats）。狀態機沿用 Issue #1 ScheduleApp pattern，但每個 sub-tab 獨立持有 `loading/error/empty/ok` 狀態，互不影響。
+
+**Tech Stack:** Astro 6 / React 19 island（`client:load`）/ Tailwind 4 / TypeScript strict / Vitest（unit + integration）/ Playwright（E2E，已由 qa-v2 產出）。
+
+**個人風格規則**：命中 2 條 — style-skeleton-loading, style-rwd-list（mobile boxscore 因 Issue 規格優先採橫向捲動，leaders 仍遵循垂直堆疊；下方 Style Rules section 詳述）
+
+**Code Graph**：圖未建立，跳過
+
+---
+
+## Coverage Matrix（從 docs/delivery/issue-4_qaplan.md 完整載入）
+
+| qaplan ID | 描述 | 對應 Task | 覆蓋方式 |
+|-----------|------|-----------|---------|
+| U-1 | transformBoxscore 22 行偏移 | Task 1 Step 1 | unit `tests/unit/boxscore-utils.test.ts` |
+| U-2 | totals 計算（排除 DNP） | Task 1 Step 1 | unit `tests/unit/boxscore-utils.test.ts` |
+| U-3 | URL query parse helper | Task 3 Step 1 | unit `tests/unit/boxscore-deep-link.test.ts` |
+| U-4 | URL update helper | Task 3 Step 1 | unit `tests/unit/boxscore-deep-link.test.ts` |
+| U-5 | 預設 tab 解析（query → leaders/boxscore） | Task 3 Step 1 | unit `tests/unit/boxscore-deep-link.test.ts` |
+| U-6 | leaders 進階指標格式化 | Task 5 Step 1 | unit `tests/unit/leaders-format.test.ts` |
+| I-1 | transformBoxscore 解析單場 | Task 1（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-2 | 多場合併解析 | Task 1（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-3 | DNP 標記 + 不計入合計 | Task 1（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-4 | 空 rows → 空 weeks | Task 1（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-5 | fetchBoxscore 成功 | Task 2（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-6 | Sheets API 500 → error | Task 2（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-7 | 網路錯誤 → error | Task 2（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-8 | fetchData('stats') 成功 | Task 5（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-9 | fetchData('stats') 全失敗 | Task 5（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| I-10 | leaders 空資料仍非 error | Task 5（既存）| integration `tests/integration/boxscore-parse.integration.test.ts` |
+| E-1 | Hero「DATA · 第 25 季」 | — | `tests/e2e/features/boxscore.spec.ts` › Hero |
+| E-2 | 副標依 tab 動態 | — | `tests/e2e/features/boxscore.spec.ts` › Hero AC-1b |
+| E-3 | 無 query → leaders | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-4 | ?tab=leaders → leaders | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-5 | ?tab=boxscore → boxscore | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-6 | 切換 tab → URL + reload | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-7 | deep link week+game → highlight | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-8 | 切回 leaders → 移除 query | — | `tests/e2e/features/boxscore.spec.ts` › Sub-tab + Deep Link |
+| E-9 | chip 顯示 + 預設當前週 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-10 | 點 chip → 6 場 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-11 | 標題 + 雙隊表格 + staff 摺疊 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-12 | staff toggle 展開/收起 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-13 | 球員表格 11 欄 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-14 | 合計 row 顯示 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-15 | DNP 視覺處理 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-16 | 球員不可點 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-17 | DNP 不計入合計 | — | `tests/e2e/features/boxscore.spec.ts` › Boxscore tab content |
+| E-18 | 6 類別卡片 | — | `tests/e2e/features/boxscore.spec.ts` › Leaders tab content |
+| E-19 | 每類 top 10 | — | `tests/e2e/features/boxscore.spec.ts` › Leaders tab content |
+| E-20 | rank/名/隊色點/值 | — | `tests/e2e/features/boxscore.spec.ts` › Leaders tab content |
+| E-21 | scoring 進階指標 | — | `tests/e2e/features/boxscore.spec.ts` › Leaders tab content |
+| E-22 | rebound 進階指標 | — | `tests/e2e/features/boxscore.spec.ts` › Leaders tab content |
+| E-23 | skeleton 載入 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-24 | boxscore Sheets 失敗限縮 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-25 | 失敗時 leaders 仍正常 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-26 | leaders 失敗限縮 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-27 | leaders 重試 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-28 | 該週 boxscore 空 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-29 | leaders 全空 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-30 | leaders 部分空 | — | `tests/e2e/features/boxscore.spec.ts` › Three-state |
+| E-31 | 桌機 RWD | — | `tests/e2e/features/boxscore.spec.ts` › RWD |
+| E-32 | 手機 RWD | — | `tests/e2e/features/boxscore.spec.ts` › RWD |
+| R-1 | 頁面載入 + 預設 leaders | — | `tests/e2e/regression/boxscore.regression.spec.ts` |
+| R-2 | 切換 tab + 切回 + 無錯誤 | — | `tests/e2e/regression/boxscore.regression.spec.ts` |
+| R-3 | deep link from schedule | — | `tests/e2e/regression/boxscore.regression.spec.ts` |
+| R-4 | 限縮 error | — | `tests/e2e/regression/boxscore.regression.spec.ts` |
+| R-5 | leaders 全空 → empty | — | `tests/e2e/regression/boxscore.regression.spec.ts` |
+
+說明：
+- I-1~I-10 的 integration test 已由 qa-v2 Phase 1.2 寫好（紅燈中），Task 1/2/5 透過實作對應 src 模組讓它由紅轉綠（不再重寫測試）。
+- U-1~U-6 的 unit test 在 qaplan 標記 ⬜（缺漏），由 Task 1 / 3 / 5 依 TDD 順序新增。
+- E-1~E-32 + R-1~R-5 已存在 `tests/e2e/features/boxscore.spec.ts` + `tests/e2e/regression/boxscore.regression.spec.ts`（紅燈中），Phase 6 由 qa-v2 跑，Task 不需動。
+
+---
+
+## 檔案結構規劃（Step 2）
+
+### 新增
+
+| 路徑 | 職責 | 對應 Task |
+|------|------|-----------|
+| `src/types/boxscore.ts` | `BoxscoreData / BoxscoreWeek / BoxscoreGame / BoxscoreTeam / BoxscorePlayer / TeamId` 型別定義（與 fixture 同形）| Task 1 |
+| `src/types/leaders.ts` | `LeaderData / LeaderSeason / LeaderEntry / LeaderCategory` 型別 | Task 5 |
+| `src/lib/boxscore-utils.ts` | `transformBoxscore(rows: string[][]): BoxscoreWeek[]` + `computeTeamTotals(players)` | Task 1 |
+| `src/lib/boxscore-api.ts` | `fetchBoxscore(): Promise<{ data, source: 'sheets' \| 'error', error? }>`（直打 Sheets API + 解析）| Task 2 |
+| `src/lib/boxscore-deep-link.ts` | `parseBoxscoreQuery(search) / buildBoxscoreUrl(state) / resolveDefaultTab(query)` | Task 3 |
+| `src/lib/leaders-format.ts` | `formatScoringAdvanced(entry) / formatReboundAdvanced(entry) / getCurrentSeasonKey(data)` | Task 5 |
+| `src/components/boxscore/BoxscoreApp.tsx` | sub-tab 控制器（URL sync、state machine、popstate listener）| Task 6 |
+| `src/components/boxscore/BoxscoreHero.tsx` | 上方 Hero header（title + 動態副標）| Task 7 |
+| `src/components/boxscore/SubTabs.tsx` | 「逐場 Box / 領先榜」sub-tab 按鈕列 | Task 6 |
+| `src/components/boxscore/BoxscorePanel.tsx` | 逐場 Box 面板（chip + 多場卡片 + 三狀態）| Task 4 |
+| `src/components/boxscore/BoxscoreGameCard.tsx` | 單場卡片（標題 + 雙隊表格 + staff toggle）| Task 4 |
+| `src/components/boxscore/BoxscoreTeamTable.tsx` | 單隊 11 欄表格 + 合計 row + DNP 樣式 | Task 4 |
+| `src/components/boxscore/BoxscoreSkeleton.tsx` | boxscore 區塊 skeleton（chip + 6 卡片骨架）| Task 4 |
+| `src/components/boxscore/BoxscoreError.tsx` | boxscore 區塊錯誤 + 重試按鈕 | Task 4 |
+| `src/components/boxscore/BoxscoreEmpty.tsx` | boxscore 區塊空狀態（該週無 Box Score）| Task 4 |
+| `src/components/boxscore/LeadersPanel.tsx` | 領先榜面板（6 類別卡片 + 三狀態）| Task 5 |
+| `src/components/boxscore/LeaderCard.tsx` | 單類別卡片（title + top 10 rows + 進階指標）| Task 5 |
+| `src/components/boxscore/LeadersSkeleton.tsx` | leaders 區塊 skeleton（6 卡片骨架）| Task 5 |
+| `src/components/boxscore/LeadersError.tsx` | leaders 區塊錯誤 + 重試按鈕 | Task 5 |
+| `src/components/boxscore/LeadersEmpty.tsx` | leaders 區塊空狀態（賽季初無資料）| Task 5 |
+| `tests/unit/boxscore-utils.test.ts` | U-1, U-2 業務邏輯 unit | Task 1 |
+| `tests/unit/boxscore-deep-link.test.ts` | U-3, U-4, U-5 業務邏輯 unit | Task 3 |
+| `tests/unit/leaders-format.test.ts` | U-6 業務邏輯 unit | Task 5 |
+
+### 修改
+
+| 路徑 | 修改內容 | 對應 Task |
+|------|---------|-----------|
+| `src/pages/boxscore.astro` | 改為 `<BoxscoreApp client:load baseUrl={baseUrl} />` wrapper（移除「規劃中」placeholder）| Task 7 |
+| `.env.example` | 新增 `PUBLIC_SHEETS_API_KEY` + `PUBLIC_SHEET_ID` 範例與註解 | Task 8 |
+
+### 不動
+
+- `src/lib/api.ts`（leaders 直接用既有 `fetchData('stats')`）
+- `src/config/teams.ts`（隊伍配色直接套用 `TEAM_CONFIG` / `getTeam`）
+- `tests/fixtures/boxscore.ts`、`tests/fixtures/leaders.ts`、`tests/helpers/mock-api.ts`（qa-v2 Phase 1.2 產出，型別與 src/types 對齊）
+- `tests/integration/boxscore-parse.integration.test.ts`（qa-v2 Phase 1.2 產出，由 Task 1/2/5 由紅轉綠）
+- `tests/e2e/features/boxscore.spec.ts`、`tests/e2e/regression/boxscore.regression.spec.ts`（qa-v2 Phase 1.2 產出，Phase 6 跑）
+
+### Task 相依圖
+
+```
+Task 1 (types/boxscore + boxscore-utils + U-1, U-2)
+  ↓
+Task 2 (boxscore-api，依賴 Task 1 的 transformBoxscore + types)
+  ↓
+Task 4 (BoxscorePanel + 子元件，依賴 Task 1 types)
+  ↓
+Task 6 (BoxscoreApp 整合，依賴 Task 3 / Task 4)
+  ↓
+Task 7 (boxscore.astro 頁面 + Hero，依賴 Task 6)
+
+Task 3 (boxscore-deep-link + U-3, U-4, U-5) 並行於 Task 1/2/4 之後，與 Task 4 並行
+Task 5 (leaders types + format + LeadersPanel + 子元件 + U-6) 完全並行於 Task 1~4
+Task 8 (.env.example) 完全獨立並行（除 Task 2 需要在 boxscore-api 讀環境變數）
+```
+
+並行群組：
+- 群組 A（並行）：Task 1、Task 5、Task 8
+- 群組 B（並行，等 A 中對應依賴）：Task 2（等 Task 1）、Task 3（無依賴，可在 A 並行）、Task 4（等 Task 1）
+- 群組 C（序列）：Task 6（等 Task 3 + Task 4 + Task 5）→ Task 7（等 Task 6）
+
+實際 subagent 派送建議：A 三個並行 → 完成後 B 三個並行 → 完成後 Task 6 → Task 7。
+
+---
+
+## Style Rules（subagent 必讀）
+
+### style-skeleton-loading（命中：BoxscoreApp / BoxscorePanel / LeadersPanel 同頁同時 fetch 兩支 API）
+
+**核心原則：** 操作立刻有視覺回饋，等待期不留白。
+
+**禁止：**
+- 整頁 spinner（`<LoadingState />` 擋住整個視口）
+- 頁面空白等資料（沒有任何佔位）
+- `mounted` 動畫 pattern（用 `opacity-0` 隱藏內容直到 JS 執行完）
+
+**本 Issue 套用方式：**
+- `BoxscoreApp` 在 React 掛載前由 Astro 已產出靜態 Hero + Sub-tab 殼（`<noscript>` 友善 + Hero 立即顯示）
+- `BoxscoreSkeleton`：1 個 chip timeline 骨架（8 個 chip 形狀色塊）+ 2 個球場卡片骨架（標題 + 兩塊表格區的色塊）
+- `LeadersSkeleton`：6 個卡片骨架（標題 + 10 行短條），桌機兩欄並排，手機單欄
+- 兩個 sub-tab 各自獨立 skeleton，不會有「整頁等到兩個 API 都好」的情況；切換 tab 立刻顯示對應 panel 的 skeleton
+- 一律 `animate-pulse` + `bg-gray-200`（沿用 Issue #1 ScheduleApp/SkeletonState 寫法）
+
+### style-rwd-list（命中：boxscore 11 欄 + leaders top 10）
+
+**規則：**
+- PC（≥md）：標準橫排 table 展開所有欄位
+- Mobile（<md）：改為 card 呈現
+
+**本 Issue 套用方式：**
+- **Leaders Panel（完全遵循）**：桌機 `md:grid-cols-2` 兩欄並排卡片；手機 `grid-cols-1` 單欄堆疊卡片，每張卡片標題 = 類別名（得分王/籃板王...）+ 內容 = top 10 「rank · 名字 · 隊色點 · 數值（+ 進階指標）」
+- **Boxscore Panel（規格優先覆寫）**：Issue #4 AC-16 明確規定「手機 <768 → boxscore 表格橫向捲動（保留 11 欄）」，因為球員數據對照需要保留 column 結構（合計 row 對齊、DNP 行視覺對齊）。實作改為 `<div class="overflow-x-auto -mx-4 px-4">` 包 11 欄 table；手機 scrollbar 用 `scrollbar-thin` Tailwind class（已於 Issue #1 註冊）+ `pb-1` 預留空間。**這是 Issue 規格覆寫風格規則，而非違反**。
+
+---
+
+## Task 1：型別 + transformBoxscore + computeTeamTotals + Unit Tests
+
+**Files:**
+- Create: `src/types/boxscore.ts`
+- Create: `src/lib/boxscore-utils.ts`
+- Test: `tests/unit/boxscore-utils.test.ts`
+- Test (existing, turn red→green): `tests/integration/boxscore-parse.integration.test.ts` (cases I-1~I-4)
+
+### Style Rules（本 task 涉及的檔案）
+無（純型別 + 解析邏輯，不涉及 UI）
+
+- [ ] **Step 1：寫失敗測試（TDD）— Unit U-1, U-2**
+
+```typescript
+// tests/unit/boxscore-utils.test.ts
+import { describe, it, expect } from 'vitest';
+import { transformBoxscore, computeTeamTotals } from '../../src/lib/boxscore-utils';
+import {
+  mockBoxscorePlayer,
+  mockDnpPlayer,
+  mockBoxscoreGame,
+  mockBoxscoreWeek,
+  mockRawBoxscoreSheetsResponse,
+} from '../fixtures/boxscore';
+
+describe('transformBoxscore', () => {
+  // Covers: U-1
+  it('U-1a: 22 行/場偏移正確（單場）→ 解析出 home/away 雙隊', () => {
+    const game = mockBoxscoreGame(5, 1, { homeTeam: '紅', awayTeam: '白', homeScore: 34, awayScore: 22 });
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].week).toBe(5);
+    expect(weeks[0].games).toHaveLength(1);
+    expect(weeks[0].games[0].home.team).toBe('紅');
+    expect(weeks[0].games[0].away.team).toBe('白');
+    expect(weeks[0].games[0].home.score).toBe(34);
+    expect(weeks[0].games[0].away.score).toBe(22);
+  });
+
+  // Covers: U-1
+  it('U-1b: 多場（同週 6 場）依 22 行 chunking 解析全部', () => {
+    const week = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse(week.games);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].games).toHaveLength(6);
+    expect(weeks[0].games.map((g) => g.game).sort()).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  // Covers: U-1
+  it('U-1c: 跨週合併（W1 + W5 兩週）→ 依 week 分組', () => {
+    const w1 = mockBoxscoreWeek(1);
+    const w5 = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse([...w1.games, ...w5.games]);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(2);
+    const found1 = weeks.find((w) => w.week === 1);
+    const found5 = weeks.find((w) => w.week === 5);
+    expect(found1?.games).toHaveLength(6);
+    expect(found5?.games).toHaveLength(6);
+  });
+
+  // Covers: U-1
+  it('U-1d: 空列陣 → 空 weeks', () => {
+    expect(transformBoxscore([])).toEqual([]);
+  });
+
+  // Covers: U-1
+  it('U-1e: 不足 22 行的尾段（殘缺）→ 略過不報錯', () => {
+    const game = mockBoxscoreGame(1, 1);
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+    const truncated = raw.values.slice(0, 10); // 半場資料
+    expect(() => transformBoxscore(truncated)).not.toThrow();
+    expect(transformBoxscore(truncated)).toEqual([]);
+  });
+});
+
+describe('computeTeamTotals', () => {
+  // Covers: U-2
+  it('U-2a: 純出賽球員 → 加總所有欄位', () => {
+    const players = [
+      mockBoxscorePlayer('A', { pts: 10, ast: 3, treb: 5 }),
+      mockBoxscorePlayer('B', { pts: 8, ast: 2, treb: 4 }),
+    ];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(18);
+    expect(totals.ast).toBe(5);
+    expect(totals.treb).toBe(9);
+  });
+
+  // Covers: U-2
+  it('U-2b: 含 DNP 球員 → DNP 不計入合計', () => {
+    const players = [
+      mockBoxscorePlayer('A', { pts: 10 }),
+      mockDnpPlayer('B'), // pts:0 dnp:true
+      mockBoxscorePlayer('C', { pts: 5 }),
+    ];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(15);
+  });
+
+  // Covers: U-2
+  it('U-2c: 全 DNP → 合計全 0', () => {
+    const players = [mockDnpPlayer('A'), mockDnpPlayer('B')];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(0);
+    expect(totals.fg2).toBe(0);
+    expect(totals.fg3).toBe(0);
+    expect(totals.ast).toBe(0);
+  });
+
+  // Covers: U-2
+  it('U-2d: 空陣列 → 全 0 totals', () => {
+    const totals = computeTeamTotals([]);
+    expect(totals.pts).toBe(0);
+    expect(totals.treb).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/boxscore-utils.test.ts tests/integration/boxscore-parse.integration.test.ts
+```
+預期：FAIL — `Cannot find module '../../src/lib/boxscore-utils'`
+
+- [ ] **Step 3：實作型別**
+
+```typescript
+// src/types/boxscore.ts
+export type TeamId = '紅' | '黑' | '藍' | '綠' | '黃' | '白';
+
+export interface BoxscorePlayer {
+  name: string;
+  pts: number;
+  fg2: number;
+  fg3: number;
+  ft: number;
+  oreb: number;
+  dreb: number;
+  treb: number;
+  ast: number;
+  stl: number;
+  blk: number;
+  tov: number;
+  pf: number;
+  /** true = 未出賽（DNP），totals 計算時排除 */
+  dnp: boolean;
+}
+
+export type BoxscoreTotals = Omit<BoxscorePlayer, 'name' | 'dnp'>;
+
+export interface BoxscoreTeam {
+  team: TeamId;
+  score: number;
+  players: BoxscorePlayer[];
+  totals: BoxscoreTotals;
+}
+
+export interface BoxscoreGame {
+  week: number;
+  game: number;
+  home: BoxscoreTeam;
+  away: BoxscoreTeam;
+  staff: Record<string, string[]>;
+}
+
+export interface BoxscoreWeek {
+  week: number;
+  games: BoxscoreGame[];
+}
+
+export interface BoxscoreData {
+  season: number;
+  currentWeek: number;
+  weeks: BoxscoreWeek[];
+}
+```
+
+- [ ] **Step 4：實作 boxscore-utils**
+
+```typescript
+// src/lib/boxscore-utils.ts
+import type {
+  BoxscorePlayer,
+  BoxscoreTotals,
+  BoxscoreTeam,
+  BoxscoreGame,
+  BoxscoreWeek,
+  TeamId,
+} from '../types/boxscore';
+
+const TEAM_IDS: TeamId[] = ['紅', '黑', '藍', '綠', '黃', '白'];
+const ROWS_PER_GAME = 22;
+
+function isTeamId(value: string): value is TeamId {
+  return (TEAM_IDS as string[]).includes(value);
+}
+
+function toNum(v: string | undefined): number {
+  if (!v) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function parsePlayerRow(row: string[]): BoxscorePlayer | null {
+  const name = (row[0] ?? '').trim();
+  if (!name) return null;
+  if (name === '合計') return null;
+
+  // DNP：名字存在但完全沒上場（所有數值為 0 或空）
+  const cells = row.slice(1, 13);
+  const allEmpty = cells.every((c) => !c || c.trim() === '' || c.trim() === '0');
+  const dnp = allEmpty;
+
+  return {
+    name,
+    pts: toNum(row[1]),
+    fg2: toNum(row[2]),
+    fg3: toNum(row[3]),
+    ft: toNum(row[4]),
+    oreb: toNum(row[5]),
+    dreb: toNum(row[6]),
+    treb: toNum(row[7]),
+    ast: toNum(row[8]),
+    stl: toNum(row[9]),
+    blk: toNum(row[10]),
+    tov: toNum(row[11]),
+    pf: toNum(row[12]),
+    dnp,
+  };
+}
+
+/**
+ * 排除 DNP 球員後加總
+ * Covers U-2 / I-3 / B-12
+ */
+export function computeTeamTotals(players: BoxscorePlayer[]): BoxscoreTotals {
+  const active = players.filter((p) => !p.dnp);
+  const sum = (key: keyof BoxscoreTotals): number =>
+    active.reduce((acc, p) => acc + (p[key] as number), 0);
+  return {
+    pts: sum('pts'),
+    fg2: sum('fg2'),
+    fg3: sum('fg3'),
+    ft: sum('ft'),
+    oreb: sum('oreb'),
+    dreb: sum('dreb'),
+    treb: sum('treb'),
+    ast: sum('ast'),
+    stl: sum('stl'),
+    blk: sum('blk'),
+    tov: sum('tov'),
+    pf: sum('pf'),
+  };
+}
+
+function parseTitleRow(row: string[]): { week: number; game: number; homeTeam: TeamId; homeScore: number; awayScore: number; awayTeam: TeamId } | null {
+  const titleCell = (row[0] ?? '').trim(); // 例：「第5週 第1場」
+  const m = titleCell.match(/第(\d+)週\s*第(\d+)場/);
+  if (!m) return null;
+  const week = Number(m[1]);
+  const game = Number(m[2]);
+
+  const homeTeamCell = (row[1] ?? '').trim();
+  const awayTeamCell = (row[5] ?? '').trim();
+  if (!isTeamId(homeTeamCell) || !isTeamId(awayTeamCell)) return null;
+
+  return {
+    week,
+    game,
+    homeTeam: homeTeamCell,
+    homeScore: toNum(row[2]),
+    awayScore: toNum(row[4]),
+    awayTeam: awayTeamCell,
+  };
+}
+
+function parseStaffRow(row: string[]): Record<string, string[]> {
+  const text = (row[0] ?? '').trim();
+  if (!text) return {};
+  const result: Record<string, string[]> = {};
+  for (const part of text.split('|')) {
+    const m = part.match(/^\s*([^:：]+)[:：]\s*(.+)\s*$/);
+    if (!m) continue;
+    const role = m[1].trim();
+    const names = m[2].split(/[,，、]/).map((s) => s.trim()).filter(Boolean);
+    if (names.length > 0) result[role] = names;
+  }
+  return result;
+}
+
+function parseGameChunk(rows: string[][]): BoxscoreGame | null {
+  if (rows.length < ROWS_PER_GAME) return null;
+
+  const title = parseTitleRow(rows[0]);
+  if (!title) return null;
+
+  // Home: rows[2..9]（8 列球員）
+  const homePlayers: BoxscorePlayer[] = [];
+  for (let i = 2; i <= 9; i++) {
+    const p = parsePlayerRow(rows[i]);
+    if (p) homePlayers.push(p);
+  }
+
+  // Away: rows[12..19]
+  const awayPlayers: BoxscorePlayer[] = [];
+  for (let i = 12; i <= 19; i++) {
+    const p = parsePlayerRow(rows[i]);
+    if (p) awayPlayers.push(p);
+  }
+
+  const home: BoxscoreTeam = {
+    team: title.homeTeam,
+    score: title.homeScore,
+    players: homePlayers,
+    totals: computeTeamTotals(homePlayers),
+  };
+  const away: BoxscoreTeam = {
+    team: title.awayTeam,
+    score: title.awayScore,
+    players: awayPlayers,
+    totals: computeTeamTotals(awayPlayers),
+  };
+
+  return {
+    week: title.week,
+    game: title.game,
+    home,
+    away,
+    staff: parseStaffRow(rows[21]),
+  };
+}
+
+/**
+ * 從 Sheets API values（22 行/場）解析回 BoxscoreWeek[]
+ * 沿用舊專案 js/page-boxscore.js 邏輯
+ *
+ * Covers U-1, I-1~I-4
+ */
+export function transformBoxscore(rows: string[][]): BoxscoreWeek[] {
+  if (!Array.isArray(rows) || rows.length < ROWS_PER_GAME) return [];
+
+  const weekMap = new Map<number, BoxscoreGame[]>();
+
+  for (let i = 0; i + ROWS_PER_GAME <= rows.length; i += ROWS_PER_GAME) {
+    const chunk = rows.slice(i, i + ROWS_PER_GAME);
+    const game = parseGameChunk(chunk);
+    if (!game) continue;
+    const list = weekMap.get(game.week) ?? [];
+    list.push(game);
+    weekMap.set(game.week, list);
+  }
+
+  return Array.from(weekMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([week, games]) => ({
+      week,
+      games: games.sort((a, b) => a.game - b.game),
+    }));
+}
+```
+
+- [ ] **Step 5：確認測試通過**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/boxscore-utils.test.ts tests/integration/boxscore-parse.integration.test.ts
+```
+預期：unit 9 個 PASS、integration I-1~I-4 PASS（I-5~I-10 仍紅，下個 task 處理）
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add src/types/boxscore.ts src/lib/boxscore-utils.ts tests/unit/boxscore-utils.test.ts
+git commit -m "feat(boxscore): add types + transformBoxscore parsing utility (Issue #4 Task 1)"
+```
+
+---
+
+## Task 2：fetchBoxscore（直打 Google Sheets API）
+
+**Files:**
+- Create: `src/lib/boxscore-api.ts`
+- Test (existing, turn red→green): `tests/integration/boxscore-parse.integration.test.ts` (cases I-5, I-6, I-7)
+
+### Style Rules（本 task 涉及的檔案）
+無（純資料層 fetcher）
+
+- [ ] **Step 1：確認既有 integration 測試是紅燈**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/integration/boxscore-parse.integration.test.ts -t "fetchBoxscore"
+```
+預期：FAIL — `Cannot find module '../../src/lib/boxscore-api'`
+
+> 說明：I-5/I-6/I-7 已由 qa-v2 寫好，本 task 只需實作 `src/lib/boxscore-api.ts` 由紅轉綠。**不重寫測試**。
+
+- [ ] **Step 2：實作 boxscore-api.ts**
+
+```typescript
+// src/lib/boxscore-api.ts
+import type { BoxscoreData } from '../types/boxscore';
+import { transformBoxscore } from './boxscore-utils';
+
+const SHEET_ID = import.meta.env.PUBLIC_SHEET_ID as string | undefined;
+const API_KEY = import.meta.env.PUBLIC_SHEETS_API_KEY as string | undefined;
+
+/**
+ * boxscore tab 的固定範圍（A1:AO1980 = 90 場 × 22 行 = 1980 列；41 欄）
+ */
+const RANGE = 'boxscore!A1:AO1980';
+
+interface FetchResult {
+  data: BoxscoreData | null;
+  source: 'sheets' | 'error';
+  error?: string;
+}
+
+/**
+ * 直打 Google Sheets API（v4 values.get）取得 boxscore tab 原始資料，
+ * 套 transformBoxscore 解析為結構化資料。
+ *
+ * Covers I-5, I-6, I-7
+ */
+export async function fetchBoxscore(): Promise<FetchResult> {
+  if (!SHEET_ID || !API_KEY) {
+    return {
+      data: null,
+      source: 'error',
+      error: 'Missing PUBLIC_SHEET_ID or PUBLIC_SHEETS_API_KEY',
+    };
+  }
+
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(SHEET_ID)}/values/${encodeURIComponent(RANGE)}?key=${encodeURIComponent(API_KEY)}`;
+
+  try {
+    const res = await fetch(url, { method: 'GET' });
+    if (!res.ok) {
+      return { data: null, source: 'error', error: `HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as { values?: string[][] };
+    const rows = json.values ?? [];
+    const weeks = transformBoxscore(rows);
+
+    // currentWeek = 最大週（fallback 1）
+    const currentWeek = weeks.length > 0 ? Math.max(...weeks.map((w) => w.week)) : 1;
+
+    return {
+      data: {
+        season: 25,
+        currentWeek,
+        weeks,
+      },
+      source: 'sheets',
+    };
+  } catch (err) {
+    return {
+      data: null,
+      source: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+```
+
+- [ ] **Step 3：確認測試通過**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/integration/boxscore-parse.integration.test.ts -t "fetchBoxscore"
+```
+預期：I-5、I-6、I-7 PASS
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add src/lib/boxscore-api.ts
+git commit -m "feat(boxscore): add fetchBoxscore Sheets API client (Issue #4 Task 2)"
+```
+
+---
+
+## Task 3：boxscore-deep-link（URL query helpers + Unit Tests）
+
+**Files:**
+- Create: `src/lib/boxscore-deep-link.ts`
+- Test: `tests/unit/boxscore-deep-link.test.ts`
+
+### Style Rules（本 task 涉及的檔案）
+無（純 URL 解析邏輯）
+
+- [ ] **Step 1：寫失敗測試（TDD）— Unit U-3, U-4, U-5**
+
+```typescript
+// tests/unit/boxscore-deep-link.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  parseBoxscoreQuery,
+  buildBoxscoreUrl,
+  resolveDefaultTab,
+  type BoxscoreUrlState,
+} from '../../src/lib/boxscore-deep-link';
+
+describe('parseBoxscoreQuery', () => {
+  // Covers: U-3
+  it('U-3a: 空 query → tab=null, week=null, game=null', () => {
+    expect(parseBoxscoreQuery('')).toEqual({ tab: null, week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3b: ?tab=leaders → 解析 tab', () => {
+    expect(parseBoxscoreQuery('?tab=leaders')).toEqual({ tab: 'leaders', week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3c: ?tab=boxscore&week=5&game=1 → 三欄都解析', () => {
+    expect(parseBoxscoreQuery('?tab=boxscore&week=5&game=1')).toEqual({ tab: 'boxscore', week: 5, game: 1 });
+  });
+
+  // Covers: U-3
+  it('U-3d: ?week=5&game=2（無 tab）→ tab=null, week=5, game=2', () => {
+    expect(parseBoxscoreQuery('?week=5&game=2')).toEqual({ tab: null, week: 5, game: 2 });
+  });
+
+  // Covers: U-3
+  it('U-3e: 不合法的 tab 值 → tab=null', () => {
+    expect(parseBoxscoreQuery('?tab=invalid')).toEqual({ tab: null, week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3f: 不合法的 week/game 數字 → 該欄 null', () => {
+    expect(parseBoxscoreQuery('?week=abc&game=xyz')).toEqual({ tab: null, week: null, game: null });
+  });
+});
+
+describe('resolveDefaultTab', () => {
+  // Covers: U-5
+  it('U-5a: 無 query → leaders（預設）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery(''))).toBe('leaders');
+  });
+
+  // Covers: U-5
+  it('U-5b: ?tab=leaders → leaders', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?tab=leaders'))).toBe('leaders');
+  });
+
+  // Covers: U-5
+  it('U-5c: ?tab=boxscore → boxscore', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?tab=boxscore'))).toBe('boxscore');
+  });
+
+  // Covers: U-5
+  it('U-5d: ?week=N&game=M（無 tab） → boxscore（隱含切到逐場）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?week=5&game=1'))).toBe('boxscore');
+  });
+
+  // Covers: U-5
+  it('U-5e: ?week=N（只有 week 沒 game） → boxscore（仍切到逐場）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?week=5'))).toBe('boxscore');
+  });
+});
+
+describe('buildBoxscoreUrl', () => {
+  const base = '/boxscore';
+
+  // Covers: U-4
+  it('U-4a: leaders tab → 不帶任何 query', () => {
+    const state: BoxscoreUrlState = { tab: 'leaders', week: null, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4b: boxscore tab 無 week/game → ?tab=boxscore', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: null, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4c: boxscore tab + week=5 → ?tab=boxscore&week=5', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: 5, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore&week=5');
+  });
+
+  // Covers: U-4
+  it('U-4d: boxscore tab + week=5 + game=1 → ?tab=boxscore&week=5&game=1', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: 5, game: 1 };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore&week=5&game=1');
+  });
+
+  // Covers: U-4 / B-22
+  it('U-4e: 從 boxscore 切回 leaders → 同時清除 week/game query', () => {
+    const state: BoxscoreUrlState = { tab: 'leaders', week: 5, game: 1 };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4f: baseUrl 帶尾斜線 → 不重複斜線', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: null, game: null };
+    expect(buildBoxscoreUrl('/boxscore/', state)).toBe('/boxscore/?tab=boxscore');
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/boxscore-deep-link.test.ts
+```
+預期：FAIL — `Cannot find module '../../src/lib/boxscore-deep-link'`
+
+- [ ] **Step 3：實作 boxscore-deep-link.ts**
+
+```typescript
+// src/lib/boxscore-deep-link.ts
+
+export type BoxscoreTab = 'leaders' | 'boxscore';
+
+export interface BoxscoreUrlState {
+  tab: BoxscoreTab | null;
+  week: number | null;
+  game: number | null;
+}
+
+const VALID_TABS: ReadonlyArray<BoxscoreTab> = ['leaders', 'boxscore'];
+
+function parsePositiveInt(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * 從 location.search（或同等 query string）解析出 tab/week/game。
+ * 不合法值 → null。
+ *
+ * Covers U-3
+ */
+export function parseBoxscoreQuery(search: string): BoxscoreUrlState {
+  if (!search || (search === '?' )) return { tab: null, week: null, game: null };
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+  const tabRaw = params.get('tab');
+  const tab = tabRaw && (VALID_TABS as ReadonlyArray<string>).includes(tabRaw) ? (tabRaw as BoxscoreTab) : null;
+
+  const week = parsePositiveInt(params.get('week'));
+  const game = parsePositiveInt(params.get('game'));
+
+  // 若 tab 不合法，視同沒帶（保守策略）；但 week/game 仍可能單獨存在
+  if (tabRaw !== null && tab === null) {
+    return { tab: null, week: null, game: null };
+  }
+
+  return { tab, week, game };
+}
+
+/**
+ * 由解析後 state 決定預設 active tab：
+ *   - tab='leaders' → leaders
+ *   - tab='boxscore' → boxscore
+ *   - 無 tab 但有 week/game → boxscore（隱含切到逐場）
+ *   - 都沒帶 → leaders（預設）
+ *
+ * Covers U-5, B-25, B-23, B-24
+ */
+export function resolveDefaultTab(state: BoxscoreUrlState): BoxscoreTab {
+  if (state.tab) return state.tab;
+  if (state.week !== null || state.game !== null) return 'boxscore';
+  return 'leaders';
+}
+
+/**
+ * 由 state 重建 URL（含 baseUrl）。
+ * - leaders tab → 完全清除 query
+ * - boxscore tab → 永遠帶 ?tab=boxscore；week/game 才帶該值
+ *
+ * Covers U-4, B-19, B-22
+ */
+export function buildBoxscoreUrl(baseUrl: string, state: BoxscoreUrlState): string {
+  if (state.tab === 'leaders' || state.tab === null) {
+    return baseUrl;
+  }
+  const params = new URLSearchParams();
+  params.set('tab', 'boxscore');
+  if (state.week !== null) params.set('week', String(state.week));
+  if (state.game !== null) params.set('game', String(state.game));
+  return `${baseUrl}?${params.toString()}`;
+}
+```
+
+- [ ] **Step 4：確認測試通過**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/boxscore-deep-link.test.ts
+```
+預期：所有 17 個 case PASS
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/lib/boxscore-deep-link.ts tests/unit/boxscore-deep-link.test.ts
+git commit -m "feat(boxscore): add deep-link URL helpers + unit tests (Issue #4 Task 3)"
+```
+
+---
+
+## Task 4：BoxscorePanel 元件群（chip + 卡片 + 表格 + 三狀態）
+
+**Files:**
+- Create: `src/components/boxscore/BoxscorePanel.tsx`
+- Create: `src/components/boxscore/BoxscoreGameCard.tsx`
+- Create: `src/components/boxscore/BoxscoreTeamTable.tsx`
+- Create: `src/components/boxscore/BoxscoreSkeleton.tsx`
+- Create: `src/components/boxscore/BoxscoreError.tsx`
+- Create: `src/components/boxscore/BoxscoreEmpty.tsx`
+
+### Style Rules（本 task 涉及的檔案）
+
+#### style-skeleton-loading（命中：BoxscorePanel 三狀態）
+- Skeleton 形狀對應真實內容：chip timeline 骨架（8 個 chip 形狀色塊）+ 6 卡片骨架（標題 + 兩塊表格區色塊）
+- 用 `animate-pulse` + `bg-gray-200`
+- 操作立刻有視覺回饋：tab 切到 boxscore → 立刻顯示 BoxscoreSkeleton（不等資料）
+- 禁止整頁 spinner / 禁止空白等資料
+
+#### style-rwd-list（命中：11 欄表格）
+- **規格優先覆寫**：本元件保留 11 欄 table（不切 mobile card），改用 `overflow-x-auto -mx-4 px-4` 容器讓手機橫向捲動。理由：球員數據對照需要 column 對齊（合計 row + DNP 視覺）。
+- 桌機 ≥md：完整顯示 11 欄不需捲動
+- DNP row：`text-gray-400 italic`，名字後加「(未出賽)」標籤
+
+- [ ] **Step 1：寫失敗測試（驗收以 E-9~E-17, E-23, E-24, E-28 + R-1, R-3, R-4 為主）**
+
+> 說明：本 task 主要由 qa-v2 已寫好的 E2E spec 驗收（`tests/e2e/features/boxscore.spec.ts` 對應 describe blocks），不重複寫單元測試。`computeTeamTotals` 在 Task 1 已測。本 task 確認元件 testid 命名與 spec 一致即可：
+>
+> 必要 data-testid：`bs-week-chip` / `bs-game-card` / `bs-game-title` / `bs-team-table` / `bs-totals-row` / `bs-player-row` / `bs-staff-toggle` / `bs-staff-panel` / `bs-skeleton` / `bs-error` / `bs-empty`
+>
+> 必要 data-* 屬性：chip 上 `data-active` `data-week`；game-card 上 `data-game`；team-table 上 `data-team`；player-row 上 `data-dnp`
+
+- [ ] **Step 2：實作 BoxscoreSkeleton**
+
+```typescript
+// src/components/boxscore/BoxscoreSkeleton.tsx
+export function BoxscoreSkeleton() {
+  return (
+    <div data-testid="bs-skeleton" className="px-4 md:px-8 py-6 animate-pulse">
+      {/* chip timeline 骨架 */}
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-6">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="h-9 w-12 md:w-20 bg-gray-200 rounded-lg flex-shrink-0" />
+        ))}
+      </div>
+      {/* 球場卡片骨架（2 場示意，避免太長）*/}
+      <div className="space-y-4">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="bg-gray-100 rounded-2xl p-4 space-y-3">
+            <div className="h-6 w-48 bg-gray-200 rounded" />
+            <div className="h-32 bg-gray-200 rounded" />
+            <div className="h-32 bg-gray-200 rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3：實作 BoxscoreError + BoxscoreEmpty**
+
+```typescript
+// src/components/boxscore/BoxscoreError.tsx
+interface Props {
+  onRetry: () => void;
+}
+export function BoxscoreError({ onRetry }: Props) {
+  return (
+    <div data-testid="bs-error" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入逐場數據</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}
+```
+
+```typescript
+// src/components/boxscore/BoxscoreEmpty.tsx
+export function BoxscoreEmpty() {
+  return (
+    <div data-testid="bs-empty" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">📋</div>
+      <p className="text-lg text-txt-dark">該週尚無 Box Score</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4：實作 BoxscoreTeamTable（11 欄 + 合計 + DNP 樣式）**
+
+```typescript
+// src/components/boxscore/BoxscoreTeamTable.tsx
+import type { BoxscoreTeam, BoxscorePlayer } from '../../types/boxscore';
+import { getTeam } from '../../config/teams';
+
+const COLUMNS: Array<{ key: keyof BoxscorePlayer; label: string }> = [
+  { key: 'name', label: '球員' },
+  { key: 'pts', label: '得分' },
+  { key: 'fg2', label: '2P' },
+  { key: 'fg3', label: '3P' },
+  { key: 'ft', label: 'FT' },
+  { key: 'oreb', label: 'OREB' },
+  { key: 'dreb', label: 'DREB' },
+  { key: 'treb', label: 'TREB' },
+  { key: 'ast', label: 'AST' },
+  { key: 'stl', label: 'STL' },
+  { key: 'blk', label: 'BLK' },
+  { key: 'tov', label: 'TOV' },
+  { key: 'pf', label: 'PF' },
+];
+// 11 欄 = 球員 + 10 個數據（pts, fg2, fg3, ft, treb, ast, stl, blk, tov, pf）→ 共 11 = 1 名 + 10 stats
+// 但 spec E-13 算法：以 columns row 第一格 + 10 個 stat header → 11 個 <th>
+// （oreb/dreb 為 treb 的細分，不算入 11 欄主表，可以放展開或合併）
+//
+// 改為以下 11 欄主表：球員 / 得分 / 2P / 3P / FT / TREB / AST / STL / BLK / TOV / PF
+// 進階（OREB/DREB）藏在 expand 或 sub-row（Issue 規格未強制）
+
+const MAIN_COLUMNS = [
+  { key: 'name', label: '球員' },
+  { key: 'pts', label: '得分' },
+  { key: 'fg2', label: '2P' },
+  { key: 'fg3', label: '3P' },
+  { key: 'ft', label: 'FT' },
+  { key: 'treb', label: 'TREB' },
+  { key: 'ast', label: 'AST' },
+  { key: 'stl', label: 'STL' },
+  { key: 'blk', label: 'BLK' },
+  { key: 'tov', label: 'TOV' },
+  { key: 'pf', label: 'PF' },
+] as const;
+
+interface Props {
+  team: BoxscoreTeam;
+}
+
+export function BoxscoreTeamTable({ team }: Props) {
+  const config = getTeam(team.team);
+  return (
+    <div className="overflow-x-auto -mx-4 md:mx-0 px-4 md:px-0 scrollbar-thin">
+      <table
+        data-testid="bs-team-table"
+        data-team={team.team}
+        className="w-full min-w-[640px] text-sm border-collapse"
+      >
+        <thead>
+          <tr className="border-b border-warm-2 text-txt-mid">
+            {MAIN_COLUMNS.map((col) => (
+              <th key={col.key} className="text-left px-2 py-2 font-condensed font-bold whitespace-nowrap">
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {team.players.map((p) => (
+            <tr
+              key={p.name}
+              data-testid="bs-player-row"
+              data-dnp={p.dnp}
+              className={[
+                'border-b border-warm-1',
+                p.dnp ? 'text-gray-400 italic' : 'text-txt-dark',
+              ].join(' ')}
+            >
+              <td className="px-2 py-2 whitespace-nowrap">
+                {p.name}
+                {p.dnp && <span className="ml-1 text-xs">(未出賽)</span>}
+              </td>
+              {MAIN_COLUMNS.slice(1).map((col) => (
+                <td key={col.key} className="px-2 py-2">{p[col.key as keyof BoxscorePlayer] as number}</td>
+              ))}
+            </tr>
+          ))}
+          <tr
+            data-testid="bs-totals-row"
+            className="border-t-2 border-warm-2 font-bold"
+            style={config ? { color: config.textColor } : undefined}
+          >
+            <td className="px-2 py-2">合計</td>
+            <td className="px-2 py-2">{team.totals.pts}</td>
+            <td className="px-2 py-2">{team.totals.fg2}</td>
+            <td className="px-2 py-2">{team.totals.fg3}</td>
+            <td className="px-2 py-2">{team.totals.ft}</td>
+            <td className="px-2 py-2">{team.totals.treb}</td>
+            <td className="px-2 py-2">{team.totals.ast}</td>
+            <td className="px-2 py-2">{team.totals.stl}</td>
+            <td className="px-2 py-2">{team.totals.blk}</td>
+            <td className="px-2 py-2">{team.totals.tov}</td>
+            <td className="px-2 py-2">{team.totals.pf}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5：實作 BoxscoreGameCard（標題 + 雙隊表格 + staff 摺疊）**
+
+```typescript
+// src/components/boxscore/BoxscoreGameCard.tsx
+import { useState } from 'react';
+import type { BoxscoreGame } from '../../types/boxscore';
+import { BoxscoreTeamTable } from './BoxscoreTeamTable';
+
+interface Props {
+  game: BoxscoreGame;
+  highlight?: boolean;
+}
+
+export function BoxscoreGameCard({ game, highlight = false }: Props) {
+  const [staffOpen, setStaffOpen] = useState(false);
+  const staffEntries = Object.entries(game.staff).filter(([, names]) => names.length > 0);
+  const staffCount = staffEntries.reduce((n, [, arr]) => n + arr.length, 0);
+
+  return (
+    <article
+      data-testid="bs-game-card"
+      data-game={game.game}
+      data-highlight={highlight}
+      className={[
+        'bg-white border rounded-2xl p-4 md:p-5 transition',
+        highlight ? 'border-orange ring-2 ring-orange/40' : 'border-warm-2',
+      ].join(' ')}
+    >
+      <h3
+        data-testid="bs-game-title"
+        className="font-condensed text-lg md:text-xl text-navy mb-3"
+      >
+        第 {game.week} 週 第 {game.game} 場 — {game.home.team} {game.home.score} vs {game.away.score} {game.away.team}
+      </h3>
+
+      <div className="space-y-4">
+        <BoxscoreTeamTable team={game.home} />
+        <BoxscoreTeamTable team={game.away} />
+      </div>
+
+      {staffCount > 0 && (
+        <div className="mt-3 border-t border-warm-2 pt-3">
+          <button
+            data-testid="bs-staff-toggle"
+            aria-expanded={staffOpen}
+            onClick={() => setStaffOpen((p) => !p)}
+            className="text-sm text-txt-mid hover:text-orange transition flex items-center gap-1"
+          >
+            <span aria-hidden="true">👨‍⚖️</span>
+            <span>工作人員 ({staffCount})</span>
+            <span aria-hidden="true">{staffOpen ? '▲' : '▼'}</span>
+          </button>
+          {staffOpen && (
+            <div data-testid="bs-staff-panel" className="mt-2 space-y-1 text-sm">
+              {staffEntries.map(([role, names]) => (
+                <div key={role} className="flex gap-2">
+                  <span className="text-txt-light font-bold w-12">{role}</span>
+                  <span className="text-txt-mid">{names.join('、')}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 6：實作 BoxscorePanel（chip + 卡片列表 + 三狀態 + scroll 到 game）**
+
+```typescript
+// src/components/boxscore/BoxscorePanel.tsx
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type { BoxscoreData, BoxscoreWeek } from '../../types/boxscore';
+import { fetchBoxscore } from '../../lib/boxscore-api';
+import { BoxscoreSkeleton } from './BoxscoreSkeleton';
+import { BoxscoreError } from './BoxscoreError';
+import { BoxscoreEmpty } from './BoxscoreEmpty';
+import { BoxscoreGameCard } from './BoxscoreGameCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  initialWeek: number | null;
+  initialGame: number | null;
+  onWeekChange: (week: number | null) => void;
+}
+
+export function BoxscorePanel({ initialWeek, initialGame, onWeekChange }: Props) {
+  const [data, setData] = useState<BoxscoreData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [activeWeek, setActiveWeek] = useState<number | null>(initialWeek);
+  const [reloadKey, setReloadKey] = useState(0);
+  const cardRefs = useRef<Map<number, HTMLElement>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    (async () => {
+      const result = await fetchBoxscore();
+      if (cancelled) return;
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+      const bs = result.data;
+      setData(bs);
+      if (bs.weeks.length === 0) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+      const targetWeek = activeWeek ?? bs.currentWeek;
+      const found = bs.weeks.find((w) => w.week === targetWeek) ?? bs.weeks[bs.weeks.length - 1];
+      setActiveWeek(found.week);
+      onWeekChange(found.week);
+      setStatus('ok');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  // deep-link scroll：activeWeek 切到對應週、且 initialGame 存在時，scroll 到該卡片
+  useEffect(() => {
+    if (status !== 'ok' || initialGame === null) return;
+    const el = cardRefs.current.get(initialGame);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [status, activeWeek, initialGame]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+  const handleSelectWeek = useCallback(
+    (w: number) => {
+      setActiveWeek(w);
+      onWeekChange(w);
+    },
+    [onWeekChange],
+  );
+
+  if (status === 'loading') return <BoxscoreSkeleton />;
+  if (status === 'error') return <BoxscoreError onRetry={handleRetry} />;
+  if (status === 'empty' || !data || activeWeek === null) return <BoxscoreEmpty />;
+
+  const week: BoxscoreWeek | undefined = data.weeks.find((w) => w.week === activeWeek);
+  if (!week || week.games.length === 0) return <BoxscoreEmpty />;
+
+  return (
+    <div data-testid="boxscore-panel" className="px-4 md:px-8 py-6">
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-6 scrollbar-thin" role="tablist" aria-label="週次選擇">
+        {data.weeks.map((w) => {
+          const isActive = w.week === activeWeek;
+          return (
+            <button
+              key={w.week}
+              role="tab"
+              aria-selected={isActive}
+              data-testid="bs-week-chip"
+              data-active={isActive}
+              data-week={w.week}
+              onClick={() => handleSelectWeek(w.week)}
+              className={[
+                'flex-shrink-0 px-3 md:px-4 py-2 rounded-lg font-condensed font-bold transition whitespace-nowrap',
+                isActive ? 'bg-orange text-white' : 'bg-warm-1 text-txt-mid hover:bg-warm-2',
+              ].join(' ')}
+            >
+              W{w.week}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="space-y-4 md:space-y-6">
+        {week.games.map((g) => (
+          <div
+            key={g.game}
+            ref={(el) => {
+              if (el) cardRefs.current.set(g.game, el);
+              else cardRefs.current.delete(g.game);
+            }}
+          >
+            <BoxscoreGameCard game={g} highlight={initialGame === g.game} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7：執行 type-check + 既有測試保持綠**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npx astro check
+npm test -- tests/unit tests/integration
+```
+預期：type-check PASS、Task 1~3 測試持續 PASS
+
+- [ ] **Step 8：Commit**
+
+```bash
+git add src/components/boxscore/BoxscorePanel.tsx src/components/boxscore/BoxscoreGameCard.tsx src/components/boxscore/BoxscoreTeamTable.tsx src/components/boxscore/BoxscoreSkeleton.tsx src/components/boxscore/BoxscoreError.tsx src/components/boxscore/BoxscoreEmpty.tsx
+git commit -m "feat(boxscore): add BoxscorePanel + game card + team table + 3-state components (Issue #4 Task 4)"
+```
+
+---
+
+## Task 5：Leaders types + format utils + LeadersPanel 元件群 + Unit Tests
+
+**Files:**
+- Create: `src/types/leaders.ts`
+- Create: `src/lib/leaders-format.ts`
+- Create: `src/components/boxscore/LeadersPanel.tsx`
+- Create: `src/components/boxscore/LeaderCard.tsx`
+- Create: `src/components/boxscore/LeadersSkeleton.tsx`
+- Create: `src/components/boxscore/LeadersError.tsx`
+- Create: `src/components/boxscore/LeadersEmpty.tsx`
+- Test: `tests/unit/leaders-format.test.ts`
+- Test (existing, turn red→green): `tests/integration/boxscore-parse.integration.test.ts` (cases I-8, I-9, I-10)
+
+### Style Rules（本 task 涉及的檔案）
+
+#### style-skeleton-loading（命中：LeadersPanel 三狀態）
+- LeadersSkeleton 形狀對應真實內容：6 個 `bg-gray-200 rounded-2xl` 卡片骨架，每張內含 1 個標題色塊 + 10 行短條色塊
+- 桌機 `md:grid-cols-2`、手機 `grid-cols-1`，與真實 LeadersPanel layout 一致避免 layout shift
+- `animate-pulse`、不用 spinner、不用文字
+- 操作立刻有視覺回饋：tab 切到 leaders → 立刻顯示 LeadersSkeleton
+
+#### style-rwd-list（命中：top 10 多欄列表 = card-with-rows）
+- 完全遵循：桌機 6 卡片兩欄並排（`md:grid-cols-2`）；手機單欄堆疊（`grid-cols-1`）
+- 每張卡片內部已是 card 形式（標題 + label-value 行），手機不再拆 card
+
+- [ ] **Step 1：寫失敗測試（TDD）— Unit U-6**
+
+```typescript
+// tests/unit/leaders-format.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  formatScoringAdvanced,
+  formatReboundAdvanced,
+  getCurrentSeasonKey,
+} from '../../src/lib/leaders-format';
+import { mockLeaderEntry, mockFullLeaders, mockEmptyLeaders } from '../fixtures/leaders';
+
+describe('formatScoringAdvanced', () => {
+  // Covers: U-6
+  it('U-6a: scoring entry 含 p2/p3/ft → 回傳「2P 55.6% / 3P 20.0% / FT 57.5%」格式', () => {
+    const e = mockLeaderEntry('Alice', '紅', 9.55, { p2: '55.6%', p3: '20.0%', ft: '57.5%' });
+    const formatted = formatScoringAdvanced(e);
+    expect(formatted).toContain('2P');
+    expect(formatted).toContain('55.6%');
+    expect(formatted).toContain('3P');
+    expect(formatted).toContain('20.0%');
+    expect(formatted).toContain('FT');
+    expect(formatted).toContain('57.5%');
+  });
+
+  // Covers: U-6
+  it('U-6b: 缺欄位 → 缺的部分以「—」呈現或省略，不噴錯', () => {
+    const e = mockLeaderEntry('Bob', '黑', 7);
+    expect(() => formatScoringAdvanced(e)).not.toThrow();
+    const formatted = formatScoringAdvanced(e);
+    expect(typeof formatted).toBe('string');
+  });
+});
+
+describe('formatReboundAdvanced', () => {
+  // Covers: U-6
+  it('U-6c: rebound entry 含 off/def → 回傳「OREB 2.5 / DREB 5.9」格式', () => {
+    const e = mockLeaderEntry('Charlie', '藍', 8.4, { off: 2.5, def: 5.9 });
+    const formatted = formatReboundAdvanced(e);
+    expect(formatted).toContain('2.5');
+    expect(formatted).toContain('5.9');
+  });
+
+  // Covers: U-6
+  it('U-6d: 缺 off/def → 不噴錯', () => {
+    const e = mockLeaderEntry('Dave', '黃', 7);
+    expect(() => formatReboundAdvanced(e)).not.toThrow();
+  });
+});
+
+describe('getCurrentSeasonKey', () => {
+  it('U-6e: full leaders → 回傳最新賽季 key（"25"）', () => {
+    expect(getCurrentSeasonKey(mockFullLeaders())).toBe('25');
+  });
+
+  it('U-6f: 空 LeaderData → null', () => {
+    expect(getCurrentSeasonKey({})).toBeNull();
+  });
+
+  it('U-6g: 多賽季 → 回傳數字最大的 key', () => {
+    const data = { '24': mockEmptyLeaders()['25'], '25': mockEmptyLeaders()['25'], '23': mockEmptyLeaders()['25'] };
+    expect(getCurrentSeasonKey(data)).toBe('25');
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/leaders-format.test.ts
+```
+預期：FAIL — `Cannot find module '../../src/lib/leaders-format'`
+
+- [ ] **Step 3：實作 types/leaders.ts**
+
+```typescript
+// src/types/leaders.ts
+export type LeaderCategory = 'scoring' | 'rebound' | 'assist' | 'steal' | 'block' | 'eff';
+
+export interface LeaderEntry {
+  name: string;
+  team: string;
+  val: number;
+  /** scoring 才有 */
+  p2?: string;
+  p3?: string;
+  ft?: string;
+  /** rebound 才有 */
+  off?: number;
+  def?: number;
+}
+
+export interface LeaderSeason {
+  label: string;
+  scoring: LeaderEntry[];
+  rebound: LeaderEntry[];
+  assist: LeaderEntry[];
+  steal: LeaderEntry[];
+  block: LeaderEntry[];
+  eff: LeaderEntry[];
+}
+
+export type LeaderData = Record<string, LeaderSeason>;
+```
+
+- [ ] **Step 4：實作 leaders-format.ts**
+
+```typescript
+// src/lib/leaders-format.ts
+import type { LeaderData, LeaderEntry } from '../types/leaders';
+
+/**
+ * scoring 進階指標：「2P 55.6% / 3P 20.0% / FT 57.5%」
+ * 缺值 → 「—」
+ *
+ * Covers U-6
+ */
+export function formatScoringAdvanced(e: LeaderEntry): string {
+  const p2 = e.p2 ?? '—';
+  const p3 = e.p3 ?? '—';
+  const ft = e.ft ?? '—';
+  return `2P ${p2} / 3P ${p3} / FT ${ft}`;
+}
+
+/**
+ * rebound 進階指標：「OREB 2.5 / DREB 5.9」
+ * 缺值 → 「—」
+ *
+ * Covers U-6
+ */
+export function formatReboundAdvanced(e: LeaderEntry): string {
+  const off = e.off ?? '—';
+  const def = e.def ?? '—';
+  return `OREB ${off} / DREB ${def}`;
+}
+
+/**
+ * 從 LeaderData 取最新賽季 key（數字最大）
+ *
+ * Covers U-6
+ */
+export function getCurrentSeasonKey(data: LeaderData): string | null {
+  const keys = Object.keys(data);
+  if (keys.length === 0) return null;
+  const sorted = keys
+    .map((k) => ({ k, n: Number(k) }))
+    .filter((x) => Number.isFinite(x.n))
+    .sort((a, b) => b.n - a.n);
+  return sorted.length > 0 ? sorted[0].k : keys[0];
+}
+```
+
+- [ ] **Step 5：確認 unit + integration 測試通過**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm test -- tests/unit/leaders-format.test.ts tests/integration/boxscore-parse.integration.test.ts
+```
+預期：unit 7 case PASS、I-8/I-9/I-10 PASS
+
+> 說明：I-8/I-9/I-10 的 `fetchData('stats')` 呼叫既有 `src/lib/api.ts`，本 task 不修改 api.ts，但因 leaders type 已加入，integration 應同步通過。
+
+- [ ] **Step 6：實作 LeadersSkeleton + LeadersError + LeadersEmpty**
+
+```typescript
+// src/components/boxscore/LeadersSkeleton.tsx
+export function LeadersSkeleton() {
+  return (
+    <div className="px-4 md:px-8 py-6 grid grid-cols-1 md:grid-cols-2 gap-4 animate-pulse">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="bg-gray-100 rounded-2xl p-4 space-y-2">
+          <div className="h-6 w-32 bg-gray-200 rounded mb-3" />
+          {Array.from({ length: 10 }).map((__, j) => (
+            <div key={j} className="h-4 bg-gray-200 rounded" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+```typescript
+// src/components/boxscore/LeadersError.tsx
+interface Props {
+  onRetry: () => void;
+}
+export function LeadersError({ onRetry }: Props) {
+  return (
+    <div data-testid="leaders-error" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入領先榜</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}
+```
+
+```typescript
+// src/components/boxscore/LeadersEmpty.tsx
+interface Props {
+  message?: string;
+}
+export function LeadersEmpty({ message = '賽季初尚無球員數據' }: Props) {
+  return (
+    <div data-testid="leaders-empty" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">🏀</div>
+      <p className="text-lg text-txt-dark">{message}</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7：實作 LeaderCard（單類別 top 10 + 進階指標）**
+
+```typescript
+// src/components/boxscore/LeaderCard.tsx
+import type { LeaderCategory, LeaderEntry } from '../../types/leaders';
+import { getTeam } from '../../config/teams';
+import { formatScoringAdvanced, formatReboundAdvanced } from '../../lib/leaders-format';
+import { LeadersEmpty } from './LeadersEmpty';
+
+const CATEGORY_TITLES: Record<LeaderCategory, string> = {
+  scoring: '得分王',
+  rebound: '籃板王',
+  assist: '助攻王',
+  steal: '抄截王',
+  block: '阻攻王',
+  eff: '效率王',
+};
+
+interface Props {
+  category: LeaderCategory;
+  entries: LeaderEntry[];
+}
+
+export function LeaderCard({ category, entries }: Props) {
+  return (
+    <div
+      data-testid="leaders-card"
+      data-category={category}
+      className="bg-white border border-warm-2 rounded-2xl p-4"
+    >
+      <h3 className="font-condensed text-lg text-navy mb-3 font-bold">
+        {CATEGORY_TITLES[category]}
+      </h3>
+      {entries.length === 0 ? (
+        <LeadersEmpty message="該類別尚無數據" />
+      ) : (
+        <ol className="space-y-2">
+          {entries.slice(0, 10).map((e, idx) => {
+            const rank = idx + 1;
+            const team = getTeam(e.team);
+            const advanced =
+              category === 'scoring'
+                ? formatScoringAdvanced(e)
+                : category === 'rebound'
+                  ? formatReboundAdvanced(e)
+                  : null;
+            return (
+              <li
+                key={`${rank}-${e.name}`}
+                data-testid="leader-row"
+                data-rank={rank}
+                className="flex items-center gap-2 text-sm"
+              >
+                <span className="w-6 font-bold text-txt-light">{rank}</span>
+                <span
+                  data-testid="leader-team-dot"
+                  className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: team?.color ?? '#999' }}
+                  aria-hidden="true"
+                />
+                <span data-testid="leader-name" className="flex-1 text-txt-dark">{e.name}</span>
+                <span data-testid="leader-val" className="font-condensed font-bold text-orange">
+                  {e.val.toFixed(2)}
+                </span>
+                {advanced && (
+                  <span data-testid="leader-advanced" className="text-xs text-txt-mid hidden md:inline">
+                    {advanced}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8：實作 LeadersPanel（fetchData('stats') + 6 卡片網格）**
+
+```typescript
+// src/components/boxscore/LeadersPanel.tsx
+import { useEffect, useState, useCallback } from 'react';
+import type { LeaderData } from '../../types/leaders';
+import { fetchData } from '../../lib/api';
+import { getCurrentSeasonKey } from '../../lib/leaders-format';
+import { LeadersSkeleton } from './LeadersSkeleton';
+import { LeadersError } from './LeadersError';
+import { LeadersEmpty } from './LeadersEmpty';
+import { LeaderCard } from './LeaderCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+const CATEGORIES = ['scoring', 'rebound', 'assist', 'steal', 'block', 'eff'] as const;
+
+export function LeadersPanel() {
+  const [data, setData] = useState<LeaderData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    (async () => {
+      const result = await fetchData<LeaderData>('stats');
+      if (cancelled) return;
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+      const leaders = result.data;
+      const seasonKey = getCurrentSeasonKey(leaders);
+      if (!seasonKey) {
+        setStatus('empty');
+        return;
+      }
+      const season = leaders[seasonKey];
+      const allEmpty = CATEGORIES.every((c) => (season[c]?.length ?? 0) === 0);
+      if (allEmpty) {
+        setData(leaders);
+        setStatus('empty');
+        return;
+      }
+      setData(leaders);
+      setStatus('ok');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  if (status === 'loading') return <LeadersSkeleton />;
+  if (status === 'error') return <LeadersError onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <LeadersEmpty />;
+
+  const seasonKey = getCurrentSeasonKey(data);
+  if (!seasonKey) return <LeadersEmpty />;
+  const season = data[seasonKey];
+
+  return (
+    <div data-testid="leaders-panel" className="px-4 md:px-8 py-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {CATEGORIES.map((c) => (
+        <LeaderCard key={c} category={c} entries={season[c] ?? []} />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9：執行 type-check + 全測**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npx astro check
+npm test
+```
+預期：所有 unit + integration PASS（含 I-8/I-9/I-10）
+
+- [ ] **Step 10：Commit**
+
+```bash
+git add src/types/leaders.ts src/lib/leaders-format.ts src/components/boxscore/LeadersPanel.tsx src/components/boxscore/LeaderCard.tsx src/components/boxscore/LeadersSkeleton.tsx src/components/boxscore/LeadersError.tsx src/components/boxscore/LeadersEmpty.tsx tests/unit/leaders-format.test.ts
+git commit -m "feat(boxscore): add LeadersPanel + 6-category cards + format utils + unit tests (Issue #4 Task 5)"
+```
+
+---
+
+## Task 6：BoxscoreApp 整合（sub-tab + URL sync + popstate）
+
+**Files:**
+- Create: `src/components/boxscore/BoxscoreApp.tsx`
+- Create: `src/components/boxscore/BoxscoreHero.tsx`
+- Create: `src/components/boxscore/SubTabs.tsx`
+
+### Style Rules（本 task 涉及的檔案）
+
+#### style-skeleton-loading（命中：BoxscoreApp 同頁同時 fetch boxscore + leaders 兩支 API）
+- 切換 sub-tab → 對應 panel 立即顯示自己的 skeleton（panel 內已實作）
+- BoxscoreApp 本身不阻塞 — 兩 panel 都已掛載（用 `display:none` 隱藏非 active），切換 tab 立即可見對應狀態
+- Hero + SubTabs 由 React 立即 render（state 為 client-side），不留白
+
+- [ ] **Step 1：實作 BoxscoreHero（依 active tab 切副標）**
+
+```typescript
+// src/components/boxscore/BoxscoreHero.tsx
+import type { BoxscoreTab } from '../../lib/boxscore-deep-link';
+
+interface Props {
+  activeTab: BoxscoreTab;
+  season: number;
+}
+
+export function BoxscoreHero({ activeTab, season }: Props) {
+  const subtitle = activeTab === 'leaders' ? '領先榜' : '逐場 Box';
+  return (
+    <header data-testid="data-hero" className="text-center px-4 py-6 md:py-10">
+      <h1
+        data-testid="hero-title"
+        className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2"
+      >
+        DATA · 第 {season} 季
+      </h1>
+      <p
+        data-testid="hero-subtitle"
+        className="font-condensed text-base md:text-lg text-txt-mid"
+      >
+        {subtitle}
+      </p>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2：實作 SubTabs（按鈕列）**
+
+```typescript
+// src/components/boxscore/SubTabs.tsx
+import type { BoxscoreTab } from '../../lib/boxscore-deep-link';
+
+interface Props {
+  activeTab: BoxscoreTab;
+  onSelect: (tab: BoxscoreTab) => void;
+}
+
+const TABS: Array<{ id: BoxscoreTab; label: string }> = [
+  { id: 'leaders', label: '領先榜' },
+  { id: 'boxscore', label: '逐場 Box' },
+];
+
+export function SubTabs({ activeTab, onSelect }: Props) {
+  return (
+    <div role="tablist" aria-label="數據分頁" className="flex gap-2 px-4 md:px-8 border-b border-warm-2">
+      {TABS.map((t) => {
+        const isActive = activeTab === t.id;
+        return (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={isActive}
+            data-testid="sub-tab"
+            data-tab={t.id}
+            data-active={isActive}
+            onClick={() => onSelect(t.id)}
+            className={[
+              'px-4 py-3 font-condensed font-bold transition border-b-2',
+              isActive
+                ? 'text-orange border-orange'
+                : 'text-txt-mid border-transparent hover:text-orange/80',
+            ].join(' ')}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3：實作 BoxscoreApp（核心控制器）**
+
+```typescript
+// src/components/boxscore/BoxscoreApp.tsx
+import { useCallback, useEffect, useState } from 'react';
+import {
+  parseBoxscoreQuery,
+  resolveDefaultTab,
+  buildBoxscoreUrl,
+  type BoxscoreTab,
+  type BoxscoreUrlState,
+} from '../../lib/boxscore-deep-link';
+import { BoxscoreHero } from './BoxscoreHero';
+import { SubTabs } from './SubTabs';
+import { BoxscorePanel } from './BoxscorePanel';
+import { LeadersPanel } from './LeadersPanel';
+
+interface Props {
+  /** 從 Astro 傳入：import.meta.env.BASE_URL（含尾斜線） */
+  baseUrl: string;
+}
+
+const SEASON = 25;
+
+function readUrlState(): BoxscoreUrlState {
+  if (typeof window === 'undefined') return { tab: null, week: null, game: null };
+  return parseBoxscoreQuery(window.location.search);
+}
+
+export function BoxscoreApp({ baseUrl }: Props) {
+  const initial = readUrlState();
+  const [activeTab, setActiveTab] = useState<BoxscoreTab>(resolveDefaultTab(initial));
+  const [activeWeek, setActiveWeek] = useState<number | null>(initial.week);
+  const [initialGame] = useState<number | null>(initial.game);
+
+  // popstate（瀏覽器上下頁）→ 重新解析 URL
+  useEffect(() => {
+    const handler = () => {
+      const s = readUrlState();
+      setActiveTab(resolveDefaultTab(s));
+      setActiveWeek(s.week);
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  // 切 tab → 更新 URL（leaders 清掉 week/game）
+  const handleSelectTab = useCallback(
+    (tab: BoxscoreTab) => {
+      setActiveTab(tab);
+      const next: BoxscoreUrlState =
+        tab === 'leaders'
+          ? { tab: 'leaders', week: null, game: null }
+          : { tab: 'boxscore', week: activeWeek, game: null };
+      // boxscore tab 切回時清除 highlight game（避免每次切回都 re-scroll）
+      const url = buildBoxscoreUrl(deriveBase(baseUrl), next);
+      window.history.replaceState(null, '', url);
+    },
+    [activeWeek, baseUrl],
+  );
+
+  // boxscore panel 換週時 → 同步 URL（保留 tab=boxscore）
+  const handleWeekChange = useCallback(
+    (week: number | null) => {
+      setActiveWeek(week);
+      if (activeTab !== 'boxscore') return;
+      const url = buildBoxscoreUrl(deriveBase(baseUrl), {
+        tab: 'boxscore',
+        week,
+        game: null,
+      });
+      window.history.replaceState(null, '', url);
+    },
+    [activeTab, baseUrl],
+  );
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8">
+      <BoxscoreHero activeTab={activeTab} season={SEASON} />
+      <SubTabs activeTab={activeTab} onSelect={handleSelectTab} />
+
+      {/* 兩 panel 都掛載，但只顯示 active 的 → 切換瞬間立即顯示對應 panel 的 skeleton */}
+      <div style={{ display: activeTab === 'leaders' ? 'block' : 'none' }}>
+        <LeadersPanel />
+      </div>
+      <div style={{ display: activeTab === 'boxscore' ? 'block' : 'none' }}>
+        <BoxscorePanel
+          initialWeek={activeWeek}
+          initialGame={initialGame}
+          onWeekChange={handleWeekChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * baseUrl 形如 "/" 或 "/taan-basketball-league/"
+ * 串成 "/boxscore" 或 "/taan-basketball-league/boxscore"
+ */
+function deriveBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return `${trimmed}/boxscore`;
+}
+```
+
+- [ ] **Step 4：執行 type-check + 全測**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npx astro check
+npm test
+```
+預期：type-check PASS、所有 unit + integration 持續 PASS
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/boxscore/BoxscoreApp.tsx src/components/boxscore/BoxscoreHero.tsx src/components/boxscore/SubTabs.tsx
+git commit -m "feat(boxscore): add BoxscoreApp + Hero + SubTabs with URL sync (Issue #4 Task 6)"
+```
+
+---
+
+## Task 7：boxscore.astro 頁面整合
+
+**Files:**
+- Modify: `src/pages/boxscore.astro`
+
+### Style Rules（本 task 涉及的檔案）
+
+#### style-skeleton-loading（命中：頁面 mount 時間點）
+- 用 `client:load`（與 schedule.astro 一致），React 一掛載就立即 render Hero + SubTabs + 對應 panel skeleton
+- 不用 `client:visible`（會延後到滾動才掛載）
+
+- [ ] **Step 1：改寫 boxscore.astro**
+
+```astro
+---
+// src/pages/boxscore.astro
+import Layout from '../layouts/Layout.astro';
+import { BoxscoreApp } from '../components/boxscore/BoxscoreApp';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<Layout title="比賽數據" active="data">
+  <BoxscoreApp client:load baseUrl={baseUrl} />
+</Layout>
+```
+
+- [ ] **Step 2：跑 dev server smoke check**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npx astro check
+npm run build
+```
+預期：build 成功（會輸出 `dist/boxscore/index.html` + JS chunks）
+
+- [ ] **Step 3：本地手動 smoke 確認（可選但建議）**
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npm run dev
+# 開瀏覽器：http://localhost:4321/boxscore
+# 預期：Hero「DATA · 第 25 季」+ SubTabs（leaders 預設 active）+ LeadersPanel skeleton → 接著顯示資料 or empty
+```
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add src/pages/boxscore.astro
+git commit -m "feat(boxscore): wire BoxscoreApp into /boxscore page (Issue #4 Task 7)"
+```
+
+---
+
+## Task 8：環境變數整合（.env.example）
+
+**Files:**
+- Modify: `.env.example`
+
+### Style Rules（本 task 涉及的檔案）
+無（純設定檔）
+
+- [ ] **Step 1：新增環境變數範例與註解**
+
+```bash
+# .env.example（在現有內容後追加）
+# Google Sheets API（boxscore tab 直打）
+# 部署後設定步驟：
+#   1. Google Cloud Console → APIs & Services → Credentials → 建立 API Key
+#   2. 「應用程式限制」設為「HTTP referrer」，加入：
+#      - https://waterfat.github.io/*
+#      - http://localhost:4321/*
+#   3. 「API 限制」勾選 Google Sheets API
+#   4. 將 Spreadsheet 共用權限設為「知道連結的人 — 檢視者」
+PUBLIC_SHEET_ID=REPLACE_WITH_SPREADSHEET_ID
+PUBLIC_SHEETS_API_KEY=REPLACE_WITH_API_KEY
+```
+
+實作方式：
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+cat >> .env.example <<'EOF'
+
+# Google Sheets API（boxscore tab 直打 — Issue #4）
+# 部署後設定步驟：
+#   1. Google Cloud Console → APIs & Services → Credentials → 建立 API Key
+#   2. 「應用程式限制」設為「HTTP referrer」，加入：
+#      - https://waterfat.github.io/*
+#      - http://localhost:4321/*
+#   3. 「API 限制」勾選 Google Sheets API
+#   4. 將 Spreadsheet 共用權限設為「知道連結的人 — 檢視者」
+PUBLIC_SHEET_ID=REPLACE_WITH_SPREADSHEET_ID
+PUBLIC_SHEETS_API_KEY=REPLACE_WITH_API_KEY
+EOF
+```
+
+- [ ] **Step 2：手動建立本地 .env.local 的步驟記錄到 retrospect notes（不寫入 git）**
+
+提示：subagent 不需建立 `.env.local`，由部署時 ops-v2 / 使用者手動設定。
+
+- [ ] **Step 3：Commit**
+
+```bash
+git add .env.example
+git commit -m "chore(env): add PUBLIC_SHEET_ID + PUBLIC_SHEETS_API_KEY to .env.example (Issue #4 Task 8)"
+```
+
+---
+
+## OPS 部署驗收清單（GitHub Pages）
+
+部署完成後，依以下清單人工驗收（pm-v2 Phase 5 結束、Phase 6 E2E 開始前）：
+
+### 環境變數確認
+- [ ] GitHub repo Settings → Secrets and variables → Actions：
+  - 確認 `PUBLIC_SHEET_ID` 已設定（值為實際 spreadsheet ID）
+  - 確認 `PUBLIC_SHEETS_API_KEY` 已設定（值為實際 API key）
+  - 確認 GitHub Actions workflow（`.github/workflows/deploy.yml`）有把這兩個變數透過 `env:` 帶到 build step
+- [ ] 部署完成後到 https://waterfat.github.io/taan-basketball-league/boxscore 開啟 DevTools，確認 `import.meta.env.PUBLIC_SHEET_ID` 在 client bundle 已注入（搜尋 dist 中的 hash 字串）
+
+### Sheets API key referrer 限制驗證
+- [ ] Google Cloud Console → APIs & Services → Credentials → 該 API Key：
+  - 「Application restrictions」=「HTTP referrers」
+  - 允許清單包含：
+    - `https://waterfat.github.io/*`
+    - `http://localhost:4321/*`（dev 用）
+  - 「API restrictions」=「Restrict key」→ 只勾選 Google Sheets API
+- [ ] 用 `curl` 模擬非允許 referrer 應被拒：
+  ```bash
+  curl -s -H "Referer: https://malicious.example.com" \
+    "https://sheets.googleapis.com/v4/spreadsheets/${PUBLIC_SHEET_ID}/values/boxscore!A1?key=${PUBLIC_SHEETS_API_KEY}" | head -20
+  ```
+  預期：回 403 with "API_KEY_HTTP_REFERRER_BLOCKED"
+
+### Spreadsheet 公開權限驗證
+- [ ] Google Sheets → 共用設定 →「一般存取權」=「知道連結的人」+「檢視者」
+- [ ] 用無痕視窗打開 spreadsheet URL → 不需登入即可檢視
+
+### Production smoke
+- [ ] 訪客打開 `https://waterfat.github.io/taan-basketball-league/boxscore` → 不出 console error、不出 401/403/CORS 錯誤
+- [ ] 切到「逐場 Box」分頁 → 表格正常渲染（Sheets API 200）
+- [ ] 切到「領先榜」分頁 → 6 卡片正常渲染（GAS handleStats 200）
+
+### Phase 6 E2E（由 qa-v2 自動跑，本清單僅列指令）
+
+```bash
+cd /Users/waterfat/Documents/taan-basketball-league-issue-4
+npx playwright test tests/e2e/regression/boxscore.regression.spec.ts
+npx playwright test tests/e2e/features/boxscore.spec.ts
+```
+
+驗收 spec：`tests/e2e/regression/boxscore.regression.spec.ts`（R-1~R-5）+ `tests/e2e/features/boxscore.spec.ts`（E-1~E-32）。
+
+---
+
+## 自我審查（Step 6）
+
+### Spec 覆蓋
+- B-1, B-2 → Task 6 BoxscoreHero 動態副標 ✅
+- B-3 ~ B-13 → Task 4 BoxscorePanel + GameCard + TeamTable ✅（B-12 在 Task 1 computeTeamTotals U-2 已驗）
+- B-14 ~ B-18 → Task 5 LeadersPanel + LeaderCard ✅（B-17/B-18 在 Task 5 U-6 已驗）
+- B-19 ~ B-25 → Task 3 deep-link helpers + Task 6 BoxscoreApp URL sync ✅
+- B-26 ~ B-29 → Task 4（11 欄 overflow-x-auto）+ Task 5（md:grid-cols-2）✅
+- B-30 ~ B-37 → 三狀態元件 Task 4/5（BoxscoreSkeleton/Error/Empty + LeadersSkeleton/Error/Empty）✅
+- B-38 → Task 8 .env.example + OPS 驗收清單 ✅
+- B-39, B-40 → Task 1 transformBoxscore + DNP 標記 ✅
+
+### Coverage Matrix 對齊
+- U-1, U-2 → Task 1 unit ✅
+- U-3, U-4, U-5 → Task 3 unit ✅
+- U-6 → Task 5 unit ✅
+- I-1 ~ I-4 → Task 1 由紅轉綠 ✅
+- I-5 ~ I-7 → Task 2 由紅轉綠 ✅
+- I-8 ~ I-10 → Task 5（依賴既有 fetchData('stats')）由紅轉綠 ✅
+- E-1 ~ E-32 + R-1 ~ R-5 → 由 qa-v2 Phase 6 跑既有 spec，Task 不重寫 ✅
+
+### 佔位符掃描
+- 全 task 含完整程式碼片段 ✅
+- 無 TODO / TBD / "implement later" / "Similar to Task N" ✅
+
+### 測試約束
+- Unit test 驗實際回傳值（非 assert_called）✅
+- Integration test 走真實邏輯（mock 邊界 fetch、走真實 transformBoxscore）✅
+- Integration 不依賴 dev server ✅
+- 空函式實作會讓測試失敗（每個 case 驗 deepEqual / toBe）✅
+
+### 型別一致性
+- `BoxscoreTab` 型別定義在 `src/lib/boxscore-deep-link.ts`，BoxscoreApp / BoxscoreHero / SubTabs 共用 import ✅
+- `BoxscoreData / BoxscoreWeek / BoxscoreGame / BoxscoreTeam / BoxscorePlayer / BoxscoreTotals / TeamId` 集中於 `src/types/boxscore.ts` ✅
+- `LeaderData / LeaderEntry / LeaderSeason / LeaderCategory` 集中於 `src/types/leaders.ts` ✅
+- `tests/fixtures/boxscore.ts` 與 `src/types/boxscore.ts` 同型別（Task 1 寫實作時對齊 fixture export 的型別 shape）✅

--- a/src/components/boxscore/BoxscoreApp.tsx
+++ b/src/components/boxscore/BoxscoreApp.tsx
@@ -1,0 +1,101 @@
+// src/components/boxscore/BoxscoreApp.tsx
+import { useCallback, useEffect, useState } from 'react';
+import {
+  parseBoxscoreQuery,
+  resolveDefaultTab,
+  buildBoxscoreUrl,
+  type BoxscoreTab,
+  type BoxscoreUrlState,
+} from '../../lib/boxscore-deep-link';
+import { BoxscoreHero } from './BoxscoreHero';
+import { SubTabs } from './SubTabs';
+import { BoxscorePanel } from './BoxscorePanel';
+import { LeadersPanel } from './LeadersPanel';
+
+interface Props {
+  /** 從 Astro 傳入：import.meta.env.BASE_URL（含尾斜線） */
+  baseUrl: string;
+}
+
+const SEASON = 25;
+
+function readUrlState(): BoxscoreUrlState {
+  if (typeof window === 'undefined') return { tab: null, week: null, game: null };
+  return parseBoxscoreQuery(window.location.search);
+}
+
+export function BoxscoreApp({ baseUrl }: Props) {
+  const initial = readUrlState();
+  const [activeTab, setActiveTab] = useState<BoxscoreTab>(resolveDefaultTab(initial));
+  const [activeWeek, setActiveWeek] = useState<number | null>(initial.week);
+  const [initialGame] = useState<number | null>(initial.game);
+
+  // popstate（瀏覽器上下頁）→ 重新解析 URL
+  useEffect(() => {
+    const handler = () => {
+      const s = readUrlState();
+      setActiveTab(resolveDefaultTab(s));
+      setActiveWeek(s.week);
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  // 切 tab → 更新 URL（leaders 清掉 week/game）
+  const handleSelectTab = useCallback(
+    (tab: BoxscoreTab) => {
+      setActiveTab(tab);
+      const next: BoxscoreUrlState =
+        tab === 'leaders'
+          ? { tab: 'leaders', week: null, game: null }
+          : { tab: 'boxscore', week: activeWeek, game: null };
+      // boxscore tab 切回時清除 highlight game（避免每次切回都 re-scroll）
+      const url = buildBoxscoreUrl(deriveBase(baseUrl), next);
+      window.history.replaceState(null, '', url);
+    },
+    [activeWeek, baseUrl],
+  );
+
+  // boxscore panel 換週時 → 同步 URL（保留 tab=boxscore）
+  const handleWeekChange = useCallback(
+    (week: number | null) => {
+      setActiveWeek(week);
+      if (activeTab !== 'boxscore') return;
+      const url = buildBoxscoreUrl(deriveBase(baseUrl), {
+        tab: 'boxscore',
+        week,
+        game: null,
+      });
+      window.history.replaceState(null, '', url);
+    },
+    [activeTab, baseUrl],
+  );
+
+  return (
+    <div className="max-w-6xl mx-auto pb-8">
+      <BoxscoreHero activeTab={activeTab} season={SEASON} />
+      <SubTabs activeTab={activeTab} onSelect={handleSelectTab} />
+
+      {/* 兩 panel 都掛載，但只顯示 active 的 → 切換瞬間立即顯示對應 panel 的 skeleton */}
+      <div style={{ display: activeTab === 'leaders' ? 'block' : 'none' }}>
+        <LeadersPanel />
+      </div>
+      <div style={{ display: activeTab === 'boxscore' ? 'block' : 'none' }}>
+        <BoxscorePanel
+          initialWeek={activeWeek}
+          initialGame={initialGame}
+          onWeekChange={handleWeekChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * baseUrl 形如 "/" 或 "/taan-basketball-league/"
+ * 串成 "/boxscore" 或 "/taan-basketball-league/boxscore"
+ */
+function deriveBase(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/$/, '');
+  return `${trimmed}/boxscore`;
+}

--- a/src/components/boxscore/BoxscoreEmpty.tsx
+++ b/src/components/boxscore/BoxscoreEmpty.tsx
@@ -1,0 +1,9 @@
+// src/components/boxscore/BoxscoreEmpty.tsx
+export function BoxscoreEmpty() {
+  return (
+    <div data-testid="bs-empty" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">📋</div>
+      <p className="text-lg text-txt-dark">該週尚無 Box Score</p>
+    </div>
+  );
+}

--- a/src/components/boxscore/BoxscoreError.tsx
+++ b/src/components/boxscore/BoxscoreError.tsx
@@ -1,0 +1,19 @@
+// src/components/boxscore/BoxscoreError.tsx
+interface Props {
+  onRetry: () => void;
+}
+export function BoxscoreError({ onRetry }: Props) {
+  return (
+    <div data-testid="bs-error" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入逐場數據</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}

--- a/src/components/boxscore/BoxscoreGameCard.tsx
+++ b/src/components/boxscore/BoxscoreGameCard.tsx
@@ -1,0 +1,64 @@
+// src/components/boxscore/BoxscoreGameCard.tsx
+import { useState } from 'react';
+import type { BoxscoreGame } from '../../types/boxscore';
+import { BoxscoreTeamTable } from './BoxscoreTeamTable';
+
+interface Props {
+  game: BoxscoreGame;
+  highlight?: boolean;
+}
+
+export function BoxscoreGameCard({ game, highlight = false }: Props) {
+  const [staffOpen, setStaffOpen] = useState(false);
+  const staffEntries = Object.entries(game.staff).filter(([, names]) => names.length > 0);
+  const staffCount = staffEntries.reduce((n, [, arr]) => n + arr.length, 0);
+
+  return (
+    <article
+      data-testid="bs-game-card"
+      data-game={game.game}
+      data-highlighted={highlight}
+      className={[
+        'bg-white border rounded-2xl p-4 md:p-5 transition',
+        highlight ? 'border-orange ring-2 ring-orange/40' : 'border-warm-2',
+      ].join(' ')}
+    >
+      <h3
+        data-testid="bs-game-title"
+        className="font-condensed text-lg md:text-xl text-navy mb-3"
+      >
+        第 {game.week} 週 第 {game.game} 場 — {game.home.team} {game.home.score} vs {game.away.score} {game.away.team}
+      </h3>
+
+      <div className="space-y-4">
+        <BoxscoreTeamTable team={game.home} />
+        <BoxscoreTeamTable team={game.away} />
+      </div>
+
+      {staffCount > 0 && (
+        <div className="mt-3 border-t border-warm-2 pt-3">
+          <button
+            data-testid="bs-staff-toggle"
+            aria-expanded={staffOpen}
+            onClick={() => setStaffOpen((p) => !p)}
+            className="text-sm text-txt-mid hover:text-orange transition flex items-center gap-1"
+          >
+            <span aria-hidden="true">👨‍⚖️</span>
+            <span>工作人員 ({staffCount})</span>
+            <span aria-hidden="true">{staffOpen ? '▲' : '▼'}</span>
+          </button>
+          {staffOpen && (
+            <div data-testid="bs-staff-panel" className="mt-2 space-y-1 text-sm">
+              {staffEntries.map(([role, names]) => (
+                <div key={role} className="flex gap-2">
+                  <span className="text-txt-light font-bold w-12">{role}</span>
+                  <span className="text-txt-mid">{names.join('、')}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/boxscore/BoxscoreHero.tsx
+++ b/src/components/boxscore/BoxscoreHero.tsx
@@ -1,0 +1,27 @@
+// src/components/boxscore/BoxscoreHero.tsx
+import type { BoxscoreTab } from '../../lib/boxscore-deep-link';
+
+interface Props {
+  activeTab: BoxscoreTab;
+  season: number;
+}
+
+export function BoxscoreHero({ activeTab, season }: Props) {
+  const subtitle = activeTab === 'leaders' ? '領先榜' : '逐場 Box';
+  return (
+    <header data-testid="data-hero" className="text-center px-4 py-6 md:py-10">
+      <h1
+        data-testid="hero-title"
+        className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2"
+      >
+        DATA · 第 {season} 季
+      </h1>
+      <p
+        data-testid="hero-subtitle"
+        className="font-condensed text-base md:text-lg text-txt-mid"
+      >
+        {subtitle}
+      </p>
+    </header>
+  );
+}

--- a/src/components/boxscore/BoxscorePanel.tsx
+++ b/src/components/boxscore/BoxscorePanel.tsx
@@ -1,0 +1,116 @@
+// src/components/boxscore/BoxscorePanel.tsx
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type { BoxscoreData, BoxscoreWeek } from '../../types/boxscore';
+import { fetchBoxscore } from '../../lib/boxscore-api';
+import { BoxscoreSkeleton } from './BoxscoreSkeleton';
+import { BoxscoreError } from './BoxscoreError';
+import { BoxscoreEmpty } from './BoxscoreEmpty';
+import { BoxscoreGameCard } from './BoxscoreGameCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  initialWeek: number | null;
+  initialGame: number | null;
+  onWeekChange: (week: number | null) => void;
+}
+
+export function BoxscorePanel({ initialWeek, initialGame, onWeekChange }: Props) {
+  const [data, setData] = useState<BoxscoreData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [activeWeek, setActiveWeek] = useState<number | null>(initialWeek);
+  const [reloadKey, setReloadKey] = useState(0);
+  const cardRefs = useRef<Map<number, HTMLElement>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    (async () => {
+      const result = await fetchBoxscore();
+      if (cancelled) return;
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+      const bs = result.data;
+      setData(bs);
+      if (bs.weeks.length === 0) {
+        setStatus('empty');
+        setActiveWeek(null);
+        return;
+      }
+      const targetWeek = activeWeek ?? bs.currentWeek;
+      const found = bs.weeks.find((w) => w.week === targetWeek) ?? bs.weeks[bs.weeks.length - 1];
+      setActiveWeek(found.week);
+      onWeekChange(found.week);
+      setStatus('ok');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  // deep-link scroll：activeWeek 切到對應週、且 initialGame 存在時，scroll 到該卡片
+  useEffect(() => {
+    if (status !== 'ok' || initialGame === null) return;
+    const el = cardRefs.current.get(initialGame);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [status, activeWeek, initialGame]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+  const handleSelectWeek = useCallback(
+    (w: number) => {
+      setActiveWeek(w);
+      onWeekChange(w);
+    },
+    [onWeekChange],
+  );
+
+  if (status === 'loading') return <BoxscoreSkeleton />;
+  if (status === 'error') return <BoxscoreError onRetry={handleRetry} />;
+  if (status === 'empty' || !data || activeWeek === null) return <BoxscoreEmpty />;
+
+  const week: BoxscoreWeek | undefined = data.weeks.find((w) => w.week === activeWeek);
+  if (!week || week.games.length === 0) return <BoxscoreEmpty />;
+
+  return (
+    <div data-testid="boxscore-panel" className="px-4 md:px-8 py-6">
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-6 scrollbar-thin" role="tablist" aria-label="週次選擇">
+        {data.weeks.map((w) => {
+          const isActive = w.week === activeWeek;
+          return (
+            <button
+              key={w.week}
+              role="tab"
+              aria-selected={isActive}
+              data-testid="bs-week-chip"
+              data-active={isActive}
+              data-week={w.week}
+              onClick={() => handleSelectWeek(w.week)}
+              className={[
+                'flex-shrink-0 px-3 md:px-4 py-2 rounded-lg font-condensed font-bold transition whitespace-nowrap',
+                isActive ? 'bg-orange text-white' : 'bg-warm-1 text-txt-mid hover:bg-warm-2',
+              ].join(' ')}
+            >
+              W{w.week}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="space-y-4 md:space-y-6">
+        {week.games.map((g) => (
+          <div
+            key={g.game}
+            ref={(el) => {
+              if (el) cardRefs.current.set(g.game, el);
+              else cardRefs.current.delete(g.game);
+            }}
+          >
+            <BoxscoreGameCard game={g} highlight={initialGame === g.game} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/boxscore/BoxscoreSkeleton.tsx
+++ b/src/components/boxscore/BoxscoreSkeleton.tsx
@@ -1,0 +1,23 @@
+// src/components/boxscore/BoxscoreSkeleton.tsx
+export function BoxscoreSkeleton() {
+  return (
+    <div data-testid="bs-skeleton" className="px-4 md:px-8 py-6 animate-pulse">
+      {/* chip timeline 骨架 */}
+      <div className="flex gap-2 overflow-x-auto pb-2 mb-6">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="h-9 w-12 md:w-20 bg-gray-200 rounded-lg flex-shrink-0" />
+        ))}
+      </div>
+      {/* 球場卡片骨架（2 場示意，避免太長）*/}
+      <div className="space-y-4">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="bg-gray-100 rounded-2xl p-4 space-y-3">
+            <div className="h-6 w-48 bg-gray-200 rounded" />
+            <div className="h-32 bg-gray-200 rounded" />
+            <div className="h-32 bg-gray-200 rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/boxscore/BoxscoreTeamTable.tsx
+++ b/src/components/boxscore/BoxscoreTeamTable.tsx
@@ -1,0 +1,89 @@
+// src/components/boxscore/BoxscoreTeamTable.tsx
+import type { BoxscoreTeam, BoxscorePlayer } from '../../types/boxscore';
+import { getTeam } from '../../config/teams';
+
+// 11 欄 = 球員 + 10 個數據（pts, fg2, fg3, ft, treb, ast, stl, blk, tov, pf）→ 共 11 = 1 名 + 10 stats
+// 但 spec E-13 算法：以 columns row 第一格 + 10 個 stat header → 11 個 <th>
+// （oreb/dreb 為 treb 的細分，不算入 11 欄主表，可以放展開或合併）
+//
+// 改為以下 11 欄主表：球員 / 得分 / 2P / 3P / FT / TREB / AST / STL / BLK / TOV / PF
+// 進階（OREB/DREB）藏在 expand 或 sub-row（Issue 規格未強制）
+
+const MAIN_COLUMNS = [
+  { key: 'name', label: '球員' },
+  { key: 'pts', label: '得分' },
+  { key: 'fg2', label: '2P' },
+  { key: 'fg3', label: '3P' },
+  { key: 'ft', label: 'FT' },
+  { key: 'treb', label: 'TREB' },
+  { key: 'ast', label: 'AST' },
+  { key: 'stl', label: 'STL' },
+  { key: 'blk', label: 'BLK' },
+  { key: 'tov', label: 'TOV' },
+  { key: 'pf', label: 'PF' },
+] as const;
+
+interface Props {
+  team: BoxscoreTeam;
+}
+
+export function BoxscoreTeamTable({ team }: Props) {
+  const config = getTeam(team.team);
+  return (
+    <div className="overflow-x-auto -mx-4 md:mx-0 px-4 md:px-0 scrollbar-thin">
+      <table
+        data-testid="bs-team-table"
+        data-team={team.team}
+        className="w-full min-w-[640px] text-sm border-collapse"
+      >
+        <thead>
+          <tr className="border-b border-warm-2 text-txt-mid">
+            {MAIN_COLUMNS.map((col) => (
+              <th key={col.key} className="text-left px-2 py-2 font-condensed font-bold whitespace-nowrap">
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {team.players.map((p) => (
+            <tr
+              key={p.name}
+              data-testid="bs-player-row"
+              data-dnp={p.dnp}
+              className={[
+                'border-b border-warm-1',
+                p.dnp ? 'text-gray-400 italic' : 'text-txt-dark',
+              ].join(' ')}
+            >
+              <td className="px-2 py-2 whitespace-nowrap">
+                {p.name}
+                {p.dnp && <span className="ml-1 text-xs">(未出賽)</span>}
+              </td>
+              {MAIN_COLUMNS.slice(1).map((col) => (
+                <td key={col.key} className="px-2 py-2">{p[col.key as keyof BoxscorePlayer] as number}</td>
+              ))}
+            </tr>
+          ))}
+          <tr
+            data-testid="bs-totals-row"
+            className="border-t-2 border-warm-2 font-bold"
+            style={config ? { color: config.textColor } : undefined}
+          >
+            <td className="px-2 py-2">合計</td>
+            <td className="px-2 py-2">{team.totals.pts}</td>
+            <td className="px-2 py-2">{team.totals.fg2}</td>
+            <td className="px-2 py-2">{team.totals.fg3}</td>
+            <td className="px-2 py-2">{team.totals.ft}</td>
+            <td className="px-2 py-2">{team.totals.treb}</td>
+            <td className="px-2 py-2">{team.totals.ast}</td>
+            <td className="px-2 py-2">{team.totals.stl}</td>
+            <td className="px-2 py-2">{team.totals.blk}</td>
+            <td className="px-2 py-2">{team.totals.tov}</td>
+            <td className="px-2 py-2">{team.totals.pf}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/boxscore/LeaderCard.tsx
+++ b/src/components/boxscore/LeaderCard.tsx
@@ -1,0 +1,75 @@
+// src/components/boxscore/LeaderCard.tsx
+import type { LeaderCategory, LeaderEntry } from '../../types/leaders';
+import { getTeam } from '../../config/teams';
+import { formatScoringAdvanced, formatReboundAdvanced } from '../../lib/leaders-format';
+import { LeadersEmpty } from './LeadersEmpty';
+
+const CATEGORY_TITLES: Record<LeaderCategory, string> = {
+  scoring: '得分王',
+  rebound: '籃板王',
+  assist: '助攻王',
+  steal: '抄截王',
+  block: '阻攻王',
+  eff: '效率王',
+};
+
+interface Props {
+  category: LeaderCategory;
+  entries: LeaderEntry[];
+}
+
+export function LeaderCard({ category, entries }: Props) {
+  return (
+    <div
+      data-testid="leaders-card"
+      data-category={category}
+      className="bg-white border border-warm-2 rounded-2xl p-4"
+    >
+      <h3 className="font-condensed text-lg text-navy mb-3 font-bold">
+        {CATEGORY_TITLES[category]}
+      </h3>
+      {entries.length === 0 ? (
+        <LeadersEmpty message="該類別尚無數據" />
+      ) : (
+        <ol className="space-y-2">
+          {entries.slice(0, 10).map((e, idx) => {
+            const rank = idx + 1;
+            const team = getTeam(e.team);
+            const advanced =
+              category === 'scoring'
+                ? formatScoringAdvanced(e)
+                : category === 'rebound'
+                  ? formatReboundAdvanced(e)
+                  : null;
+            return (
+              <li
+                key={`${rank}-${e.name}`}
+                data-testid="leader-row"
+                data-rank={rank}
+                className="flex items-center gap-2 text-sm"
+              >
+                <span className="w-6 font-bold text-txt-light">{rank}</span>
+                <span
+                  data-testid="leader-team-dot"
+                  data-team={e.team}
+                  className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: team?.color ?? '#999' }}
+                  aria-hidden="true"
+                />
+                <span data-testid="leader-name" className="flex-1 text-txt-dark">{e.name}</span>
+                <span data-testid="leader-val" className="font-condensed font-bold text-orange">
+                  {e.val.toFixed(2)}
+                </span>
+                {advanced && (
+                  <span data-testid="leader-advanced" className="text-xs text-txt-mid hidden md:inline">
+                    {advanced}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/src/components/boxscore/LeadersEmpty.tsx
+++ b/src/components/boxscore/LeadersEmpty.tsx
@@ -1,0 +1,12 @@
+// src/components/boxscore/LeadersEmpty.tsx
+interface Props {
+  message?: string;
+}
+export function LeadersEmpty({ message = '賽季初尚無球員數據' }: Props) {
+  return (
+    <div data-testid="leaders-empty" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">🏀</div>
+      <p className="text-lg text-txt-dark">{message}</p>
+    </div>
+  );
+}

--- a/src/components/boxscore/LeadersError.tsx
+++ b/src/components/boxscore/LeadersError.tsx
@@ -1,0 +1,19 @@
+// src/components/boxscore/LeadersError.tsx
+interface Props {
+  onRetry: () => void;
+}
+export function LeadersError({ onRetry }: Props) {
+  return (
+    <div data-testid="leaders-error" className="px-4 py-12 max-w-md mx-auto text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入領先榜</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}

--- a/src/components/boxscore/LeadersPanel.tsx
+++ b/src/components/boxscore/LeadersPanel.tsx
@@ -1,0 +1,67 @@
+// src/components/boxscore/LeadersPanel.tsx
+import { useEffect, useState, useCallback } from 'react';
+import type { LeaderData } from '../../types/leaders';
+import { fetchData } from '../../lib/api';
+import { getCurrentSeasonKey } from '../../lib/leaders-format';
+import { LeadersSkeleton } from './LeadersSkeleton';
+import { LeadersError } from './LeadersError';
+import { LeadersEmpty } from './LeadersEmpty';
+import { LeaderCard } from './LeaderCard';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+const CATEGORIES = ['scoring', 'rebound', 'assist', 'steal', 'block', 'eff'] as const;
+
+export function LeadersPanel() {
+  const [data, setData] = useState<LeaderData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    (async () => {
+      const result = await fetchData<LeaderData>('stats');
+      if (cancelled) return;
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+      const leaders = result.data;
+      const seasonKey = getCurrentSeasonKey(leaders);
+      if (!seasonKey) {
+        setStatus('empty');
+        return;
+      }
+      const season = leaders[seasonKey];
+      const allEmpty = CATEGORIES.every((c) => (season[c]?.length ?? 0) === 0);
+      if (allEmpty) {
+        setData(leaders);
+        setStatus('empty');
+        return;
+      }
+      setData(leaders);
+      setStatus('ok');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  if (status === 'loading') return <LeadersSkeleton />;
+  if (status === 'error') return <LeadersError onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <LeadersEmpty />;
+
+  const seasonKey = getCurrentSeasonKey(data);
+  if (!seasonKey) return <LeadersEmpty />;
+  const season = data[seasonKey];
+
+  return (
+    <div data-testid="leaders-panel" className="px-4 md:px-8 py-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {CATEGORIES.map((c) => (
+        <LeaderCard key={c} category={c} entries={season[c] ?? []} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/boxscore/LeadersSkeleton.tsx
+++ b/src/components/boxscore/LeadersSkeleton.tsx
@@ -1,0 +1,18 @@
+// src/components/boxscore/LeadersSkeleton.tsx
+export function LeadersSkeleton() {
+  return (
+    <div
+      data-testid="leaders-skeleton"
+      className="px-4 md:px-8 py-6 grid grid-cols-1 md:grid-cols-2 gap-4 animate-pulse"
+    >
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="bg-gray-100 rounded-2xl p-4 space-y-2">
+          <div className="h-6 w-32 bg-gray-200 rounded mb-3" />
+          {Array.from({ length: 10 }).map((__, j) => (
+            <div key={j} className="h-4 bg-gray-200 rounded" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/boxscore/SubTabs.tsx
+++ b/src/components/boxscore/SubTabs.tsx
@@ -1,0 +1,41 @@
+// src/components/boxscore/SubTabs.tsx
+import type { BoxscoreTab } from '../../lib/boxscore-deep-link';
+
+interface Props {
+  activeTab: BoxscoreTab;
+  onSelect: (tab: BoxscoreTab) => void;
+}
+
+const TABS: Array<{ id: BoxscoreTab; label: string }> = [
+  { id: 'leaders', label: '領先榜' },
+  { id: 'boxscore', label: '逐場 Box' },
+];
+
+export function SubTabs({ activeTab, onSelect }: Props) {
+  return (
+    <div role="tablist" aria-label="數據分頁" className="flex gap-2 px-4 md:px-8 border-b border-warm-2">
+      {TABS.map((t) => {
+        const isActive = activeTab === t.id;
+        return (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={isActive}
+            data-testid="sub-tab"
+            data-tab={t.id}
+            data-active={isActive}
+            onClick={() => onSelect(t.id)}
+            className={[
+              'px-4 py-3 font-condensed font-bold transition border-b-2',
+              isActive
+                ? 'text-orange border-orange'
+                : 'text-txt-mid border-transparent hover:text-orange/80',
+            ].join(' ')}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/boxscore-api.ts
+++ b/src/lib/boxscore-api.ts
@@ -1,0 +1,62 @@
+import type { BoxscoreData } from '../types/boxscore';
+import { transformBoxscore } from './boxscore-utils';
+
+const SHEET_ID = import.meta.env.PUBLIC_SHEET_ID as string | undefined;
+const API_KEY = import.meta.env.PUBLIC_SHEETS_API_KEY as string | undefined;
+
+/**
+ * boxscore tab 的固定範圍（A1:AO1980 = 90 場 × 22 行 = 1980 列；41 欄）
+ */
+const RANGE = 'boxscore!A1:AO1980';
+
+interface FetchResult {
+  data: BoxscoreData | null;
+  source: 'sheets' | 'error';
+  error?: string;
+}
+
+/**
+ * 直打 Google Sheets API（v4 values.get）取得 boxscore tab 原始資料，
+ * 套 transformBoxscore 解析為結構化資料。
+ *
+ * Covers I-5, I-6, I-7
+ */
+export async function fetchBoxscore(): Promise<FetchResult> {
+  if (!SHEET_ID || !API_KEY) {
+    return {
+      data: null,
+      source: 'error',
+      error: 'Missing PUBLIC_SHEET_ID or PUBLIC_SHEETS_API_KEY',
+    };
+  }
+
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(SHEET_ID)}/values/${encodeURIComponent(RANGE)}?key=${encodeURIComponent(API_KEY)}`;
+
+  try {
+    const res = await fetch(url, { method: 'GET' });
+    if (!res.ok) {
+      return { data: null, source: 'error', error: `HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as { values?: string[][] };
+    const rows = json.values ?? [];
+    const weeks = transformBoxscore(rows);
+
+    // currentWeek = 最大週（fallback 1）
+    const currentWeek = weeks.length > 0 ? Math.max(...weeks.map((w) => w.week)) : 1;
+
+    return {
+      data: {
+        season: 25,
+        currentWeek,
+        weeks,
+      },
+      source: 'sheets',
+    };
+  } catch (err) {
+    return {
+      data: null,
+      source: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/lib/boxscore-deep-link.ts
+++ b/src/lib/boxscore-deep-link.ts
@@ -1,0 +1,73 @@
+export type BoxscoreTab = 'leaders' | 'boxscore';
+
+export interface BoxscoreUrlState {
+  tab: BoxscoreTab | null;
+  week: number | null;
+  game: number | null;
+}
+
+const VALID_TABS: ReadonlyArray<BoxscoreTab> = ['leaders', 'boxscore'];
+
+function parsePositiveInt(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * 從 location.search（或同等 query string）解析出 tab/week/game。
+ * 不合法值 → null。
+ *
+ * Covers U-3
+ */
+export function parseBoxscoreQuery(search: string): BoxscoreUrlState {
+  if (!search || (search === '?' )) return { tab: null, week: null, game: null };
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+  const tabRaw = params.get('tab');
+  const tab = tabRaw && (VALID_TABS as ReadonlyArray<string>).includes(tabRaw) ? (tabRaw as BoxscoreTab) : null;
+
+  const week = parsePositiveInt(params.get('week'));
+  const game = parsePositiveInt(params.get('game'));
+
+  // 若 tab 不合法，視同沒帶（保守策略）；但 week/game 仍可能單獨存在
+  if (tabRaw !== null && tab === null) {
+    return { tab: null, week: null, game: null };
+  }
+
+  return { tab, week, game };
+}
+
+/**
+ * 由解析後 state 決定預設 active tab：
+ *   - tab='leaders' → leaders
+ *   - tab='boxscore' → boxscore
+ *   - 無 tab 但有 week/game → boxscore（隱含切到逐場）
+ *   - 都沒帶 → leaders（預設）
+ *
+ * Covers U-5, B-25, B-23, B-24
+ */
+export function resolveDefaultTab(state: BoxscoreUrlState): BoxscoreTab {
+  if (state.tab) return state.tab;
+  if (state.week !== null || state.game !== null) return 'boxscore';
+  return 'leaders';
+}
+
+/**
+ * 由 state 重建 URL（含 baseUrl）。
+ * - leaders tab → 完全清除 query
+ * - boxscore tab → 永遠帶 ?tab=boxscore；week/game 才帶該值
+ *
+ * Covers U-4, B-19, B-22
+ */
+export function buildBoxscoreUrl(baseUrl: string, state: BoxscoreUrlState): string {
+  if (state.tab === 'leaders' || state.tab === null) {
+    return baseUrl;
+  }
+  const params = new URLSearchParams();
+  params.set('tab', 'boxscore');
+  if (state.week !== null) params.set('week', String(state.week));
+  if (state.game !== null) params.set('game', String(state.game));
+  return `${baseUrl}?${params.toString()}`;
+}

--- a/src/lib/boxscore-utils.ts
+++ b/src/lib/boxscore-utils.ts
@@ -1,0 +1,178 @@
+import type {
+  BoxscorePlayer,
+  BoxscoreTotals,
+  BoxscoreTeam,
+  BoxscoreGame,
+  BoxscoreWeek,
+  TeamId,
+} from '../types/boxscore';
+
+const TEAM_IDS: TeamId[] = ['紅', '黑', '藍', '綠', '黃', '白'];
+const ROWS_PER_GAME = 22;
+
+function isTeamId(value: string): value is TeamId {
+  return (TEAM_IDS as string[]).includes(value);
+}
+
+function toNum(v: string | undefined): number {
+  if (!v) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function parsePlayerRow(row: string[]): BoxscorePlayer | null {
+  const name = (row[0] ?? '').trim();
+  if (!name) return null;
+  if (name === '合計') return null;
+
+  // DNP：名字存在但完全沒上場（所有數值為 0 或空）
+  const cells = row.slice(1, 13);
+  const allEmpty = cells.every((c) => !c || c.trim() === '' || c.trim() === '0');
+  const dnp = allEmpty;
+
+  return {
+    name,
+    pts: toNum(row[1]),
+    fg2: toNum(row[2]),
+    fg3: toNum(row[3]),
+    ft: toNum(row[4]),
+    oreb: toNum(row[5]),
+    dreb: toNum(row[6]),
+    treb: toNum(row[7]),
+    ast: toNum(row[8]),
+    stl: toNum(row[9]),
+    blk: toNum(row[10]),
+    tov: toNum(row[11]),
+    pf: toNum(row[12]),
+    dnp,
+  };
+}
+
+/**
+ * 排除 DNP 球員後加總
+ * Covers U-2 / I-3 / B-12
+ */
+export function computeTeamTotals(players: BoxscorePlayer[]): BoxscoreTotals {
+  const active = players.filter((p) => !p.dnp);
+  const sum = (key: keyof BoxscoreTotals): number =>
+    active.reduce((acc, p) => acc + (p[key] as number), 0);
+  return {
+    pts: sum('pts'),
+    fg2: sum('fg2'),
+    fg3: sum('fg3'),
+    ft: sum('ft'),
+    oreb: sum('oreb'),
+    dreb: sum('dreb'),
+    treb: sum('treb'),
+    ast: sum('ast'),
+    stl: sum('stl'),
+    blk: sum('blk'),
+    tov: sum('tov'),
+    pf: sum('pf'),
+  };
+}
+
+function parseTitleRow(row: string[]): { week: number; game: number; homeTeam: TeamId; homeScore: number; awayScore: number; awayTeam: TeamId } | null {
+  const titleCell = (row[0] ?? '').trim(); // 例：「第5週 第1場」
+  const m = titleCell.match(/第(\d+)週\s*第(\d+)場/);
+  if (!m) return null;
+  const week = Number(m[1]);
+  const game = Number(m[2]);
+
+  const homeTeamCell = (row[1] ?? '').trim();
+  const awayTeamCell = (row[5] ?? '').trim();
+  if (!isTeamId(homeTeamCell) || !isTeamId(awayTeamCell)) return null;
+
+  return {
+    week,
+    game,
+    homeTeam: homeTeamCell,
+    homeScore: toNum(row[2]),
+    awayScore: toNum(row[4]),
+    awayTeam: awayTeamCell,
+  };
+}
+
+function parseStaffRow(row: string[]): Record<string, string[]> {
+  const text = (row[0] ?? '').trim();
+  if (!text) return {};
+  const result: Record<string, string[]> = {};
+  for (const part of text.split('|')) {
+    const m = part.match(/^\s*([^:：]+)[:：]\s*(.+)\s*$/);
+    if (!m) continue;
+    const role = m[1].trim();
+    const names = m[2].split(/[,，、]/).map((s) => s.trim()).filter(Boolean);
+    if (names.length > 0) result[role] = names;
+  }
+  return result;
+}
+
+function parseGameChunk(rows: string[][]): BoxscoreGame | null {
+  if (rows.length < ROWS_PER_GAME) return null;
+
+  const title = parseTitleRow(rows[0]);
+  if (!title) return null;
+
+  // Home: rows[2..9]（8 列球員）
+  const homePlayers: BoxscorePlayer[] = [];
+  for (let i = 2; i <= 9; i++) {
+    const p = parsePlayerRow(rows[i]);
+    if (p) homePlayers.push(p);
+  }
+
+  // Away: rows[12..19]
+  const awayPlayers: BoxscorePlayer[] = [];
+  for (let i = 12; i <= 19; i++) {
+    const p = parsePlayerRow(rows[i]);
+    if (p) awayPlayers.push(p);
+  }
+
+  const home: BoxscoreTeam = {
+    team: title.homeTeam,
+    score: title.homeScore,
+    players: homePlayers,
+    totals: computeTeamTotals(homePlayers),
+  };
+  const away: BoxscoreTeam = {
+    team: title.awayTeam,
+    score: title.awayScore,
+    players: awayPlayers,
+    totals: computeTeamTotals(awayPlayers),
+  };
+
+  return {
+    week: title.week,
+    game: title.game,
+    home,
+    away,
+    staff: parseStaffRow(rows[21]),
+  };
+}
+
+/**
+ * 從 Sheets API values（22 行/場）解析回 BoxscoreWeek[]
+ * 沿用舊專案 js/page-boxscore.js 邏輯
+ *
+ * Covers U-1, I-1~I-4
+ */
+export function transformBoxscore(rows: string[][]): BoxscoreWeek[] {
+  if (!Array.isArray(rows) || rows.length < ROWS_PER_GAME) return [];
+
+  const weekMap = new Map<number, BoxscoreGame[]>();
+
+  for (let i = 0; i + ROWS_PER_GAME <= rows.length; i += ROWS_PER_GAME) {
+    const chunk = rows.slice(i, i + ROWS_PER_GAME);
+    const game = parseGameChunk(chunk);
+    if (!game) continue;
+    const list = weekMap.get(game.week) ?? [];
+    list.push(game);
+    weekMap.set(game.week, list);
+  }
+
+  return Array.from(weekMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([week, games]) => ({
+      week,
+      games: games.sort((a, b) => a.game - b.game),
+    }));
+}

--- a/src/lib/leaders-format.ts
+++ b/src/lib/leaders-format.ts
@@ -1,0 +1,42 @@
+// src/lib/leaders-format.ts
+import type { LeaderData, LeaderEntry } from '../types/leaders';
+
+/**
+ * scoring 進階指標：「2P 55.6% / 3P 20.0% / FT 57.5%」
+ * 缺值 → 「—」
+ *
+ * Covers U-6
+ */
+export function formatScoringAdvanced(e: LeaderEntry): string {
+  const p2 = e.p2 ?? '—';
+  const p3 = e.p3 ?? '—';
+  const ft = e.ft ?? '—';
+  return `2P ${p2} / 3P ${p3} / FT ${ft}`;
+}
+
+/**
+ * rebound 進階指標：「OREB 2.5 / DREB 5.9」
+ * 缺值 → 「—」
+ *
+ * Covers U-6
+ */
+export function formatReboundAdvanced(e: LeaderEntry): string {
+  const off = e.off ?? '—';
+  const def = e.def ?? '—';
+  return `OREB ${off} / DREB ${def}`;
+}
+
+/**
+ * 從 LeaderData 取最新賽季 key（數字最大）
+ *
+ * Covers U-6
+ */
+export function getCurrentSeasonKey(data: LeaderData): string | null {
+  const keys = Object.keys(data);
+  if (keys.length === 0) return null;
+  const sorted = keys
+    .map((k) => ({ k, n: Number(k) }))
+    .filter((x) => Number.isFinite(x.n))
+    .sort((a, b) => b.n - a.n);
+  return sorted.length > 0 ? sorted[0].k : keys[0];
+}

--- a/src/pages/boxscore.astro
+++ b/src/pages/boxscore.astro
@@ -1,14 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import { BoxscoreApp } from '../components/boxscore/BoxscoreApp';
+
+const baseUrl = import.meta.env.BASE_URL;
 ---
 
 <Layout title="比賽數據" active="data">
-  <section class="px-4 md:px-8 py-8 max-w-6xl mx-auto">
-    <h1 class="font-display text-3xl md:text-5xl text-navy tracking-wider mb-2">比賽數據</h1>
-    <p class="text-txt-mid mb-8">逐場 Box Score、球員個人數據</p>
-
-    <div class="bg-white border border-warm-2 rounded-2xl p-8 text-center">
-      <p class="font-condensed text-2xl text-orange mb-2">規劃中</p>
-    </div>
-  </section>
+  <BoxscoreApp client:load baseUrl={baseUrl} />
 </Layout>

--- a/src/types/boxscore.ts
+++ b/src/types/boxscore.ts
@@ -1,0 +1,47 @@
+export type TeamId = '紅' | '黑' | '藍' | '綠' | '黃' | '白';
+
+export interface BoxscorePlayer {
+  name: string;
+  pts: number;
+  fg2: number;
+  fg3: number;
+  ft: number;
+  oreb: number;
+  dreb: number;
+  treb: number;
+  ast: number;
+  stl: number;
+  blk: number;
+  tov: number;
+  pf: number;
+  /** true = 未出賽（DNP），totals 計算時排除 */
+  dnp: boolean;
+}
+
+export type BoxscoreTotals = Omit<BoxscorePlayer, 'name' | 'dnp'>;
+
+export interface BoxscoreTeam {
+  team: TeamId;
+  score: number;
+  players: BoxscorePlayer[];
+  totals: BoxscoreTotals;
+}
+
+export interface BoxscoreGame {
+  week: number;
+  game: number;
+  home: BoxscoreTeam;
+  away: BoxscoreTeam;
+  staff: Record<string, string[]>;
+}
+
+export interface BoxscoreWeek {
+  week: number;
+  games: BoxscoreGame[];
+}
+
+export interface BoxscoreData {
+  season: number;
+  currentWeek: number;
+  weeks: BoxscoreWeek[];
+}

--- a/src/types/leaders.ts
+++ b/src/types/leaders.ts
@@ -1,0 +1,27 @@
+// src/types/leaders.ts
+export type LeaderCategory = 'scoring' | 'rebound' | 'assist' | 'steal' | 'block' | 'eff';
+
+export interface LeaderEntry {
+  name: string;
+  team: string;
+  val: number;
+  /** scoring 才有 */
+  p2?: string;
+  p3?: string;
+  ft?: string;
+  /** rebound 才有 */
+  off?: number;
+  def?: number;
+}
+
+export interface LeaderSeason {
+  label: string;
+  scoring: LeaderEntry[];
+  rebound: LeaderEntry[];
+  assist: LeaderEntry[];
+  steal: LeaderEntry[];
+  block: LeaderEntry[];
+  eff: LeaderEntry[];
+}
+
+export type LeaderData = Record<string, LeaderSeason>;

--- a/tests/e2e/features/boxscore.spec.ts
+++ b/tests/e2e/features/boxscore.spec.ts
@@ -1,0 +1,462 @@
+/**
+ * /boxscore 數據頁 E2E
+ *
+ * Tag: @boxscore
+ * Coverage: AC-1 ~ AC-21（AC-22/23 屬於環境設定，不在 E2E 涵蓋）+ qa-v2 補充
+ *
+ * 測試資料策略：
+ * - boxscore tab：mockBoxscoreSheetsAPI() 攔截 sheets.googleapis.com（直打 Sheets API）
+ * - leaders tab：mockLeadersAPI() 攔截 GAS stats endpoint + JSON fallback
+ * - 不打 production Google Sheets / GAS
+ *
+ * Sub-tab Deep Link 規則：
+ *   /boxscore                       → leaders tab（預設）
+ *   /boxscore?tab=leaders           → leaders tab
+ *   /boxscore?tab=boxscore          → boxscore tab
+ *   /boxscore?week=N&game=M         → boxscore tab + chip W{N} + scroll 到第 M 場 + highlight
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  mockBoxscoreWeek,
+  mockBoxscoreGame,
+} from '../../fixtures/boxscore';
+import {
+  mockFullLeaders,
+  mockEmptyLeaders,
+  mockPartialLeaders,
+} from '../../fixtures/leaders';
+import {
+  mockBoxscoreSheetsAPI,
+  mockLeadersAPI,
+  mockBoxscoreAndLeaders,
+} from '../../helpers/mock-api';
+
+const ALL_BOX_GAMES = [
+  ...mockBoxscoreWeek(1).games,
+  ...mockBoxscoreWeek(5).games,
+  ...mockBoxscoreWeek(6).games,
+];
+
+test.describe('Boxscore Page — Hero @boxscore', () => {
+  // ────── AC-1: Hero header 顯示 + 副標 ──────
+  test('AC-1: 訪客打開 /boxscore → Hero header「DATA · 第 25 季」', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore');
+
+    // UI 結構
+    const hero = page.locator('[data-testid="data-hero"]');
+    await expect(hero).toBeVisible();
+    await expect(hero.locator('[data-testid="hero-title"]')).toContainText(/DATA/i);
+    await expect(hero.locator('[data-testid="hero-title"]')).toContainText(/第\s*25\s*季|S25/);
+  });
+
+  // ────── AC-1 副標動態 ──────
+  test('AC-1b: Hero 副標依 active tab 動態變化（leaders → boxscore）', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore'); // 預設 leaders
+
+    const subtitle = page.locator('[data-testid="hero-subtitle"]');
+    await expect(subtitle).toContainText(/領先榜/);
+
+    // 切到 boxscore tab
+    await page.locator('[data-testid="sub-tab"][data-tab="boxscore"]').click();
+    await expect(subtitle).toContainText(/逐場\s*Box/);
+  });
+});
+
+test.describe('Boxscore Sub-tab + Deep Link @boxscore', () => {
+  // ────── AC-14: 預設 leaders tab ──────
+  test('AC-14: 無 query 進入 → 預設 leaders tab active', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore');
+
+    const leadersTab = page.locator('[data-testid="sub-tab"][data-tab="leaders"]');
+    const boxscoreTab = page.locator('[data-testid="sub-tab"][data-tab="boxscore"]');
+    await expect(leadersTab).toHaveAttribute('data-active', 'true');
+    await expect(boxscoreTab).toHaveAttribute('data-active', 'false');
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+  });
+
+  // ────── AC-13: ?tab=leaders 直接進入 ──────
+  test('AC-13: /boxscore?tab=leaders 直接進入 → leaders tab', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="leaders"]')).toHaveAttribute('data-active', 'true');
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+  });
+
+  // ────── AC-13b: ?tab=boxscore 直接進入 ──────
+  test('AC-13b: /boxscore?tab=boxscore 直接進入 → boxscore tab', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="boxscore"]')).toHaveAttribute('data-active', 'true');
+    await expect(page.locator('[data-testid="boxscore-panel"]')).toBeVisible();
+  });
+
+  // ────── AC-11: 切換 tab 更新 URL + reload 仍停留 ──────
+  test('AC-11: 切換 tab → URL 變更 + reload 仍停留', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore'); // leaders 預設
+
+    await page.locator('[data-testid="sub-tab"][data-tab="boxscore"]').click();
+    await expect(page).toHaveURL(/[?&]tab=boxscore(&|$)/);
+
+    // reload 仍在 boxscore
+    await page.reload();
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="boxscore"]')).toHaveAttribute('data-active', 'true');
+  });
+
+  // ────── AC-12: deep link from /schedule ──────
+  test('AC-12: /boxscore?week=5&game=1 → boxscore tab + chip W5 + 第 1 場 highlight + scroll', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?week=5&game=1');
+
+    // 自動切 boxscore tab
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="boxscore"]')).toHaveAttribute('data-active', 'true');
+
+    // chip W5 為 active
+    const activeChip = page.locator('[data-testid="bs-week-chip"][data-active="true"]');
+    await expect(activeChip).toContainText(/5/);
+
+    // 第 1 場卡片 highlight + 在視窗內
+    const card = page.locator('[data-testid="bs-game-card"][data-game="1"]');
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute('data-highlighted', 'true');
+    await expect(card).toBeInViewport({ timeout: 3000 });
+  });
+
+  // ────── [qa-v2 補充] 切回 leaders 後 highlight 移除 ──────
+  test('[qa-v2 補充] AC-12b: 從 deep link 進入後切回 leaders → URL 移除 week/game query', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?week=5&game=1');
+
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+
+    await expect(page).toHaveURL(/[?&]tab=leaders/);
+    await expect(page).not.toHaveURL(/week=/);
+    await expect(page).not.toHaveURL(/game=/);
+  });
+});
+
+test.describe('Boxscore Tab — chip + game cards @boxscore', () => {
+  // ────── AC-2: chip timeline 切週 + 預設當前週 ──────
+  test('AC-2: 進入 boxscore tab → chip timeline 顯示，預設當前週 active', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const activeChip = page.locator('[data-testid="bs-week-chip"][data-active="true"]');
+    await expect(activeChip).toContainText(/5/); // mockFullBoxscore.currentWeek = 5
+  });
+
+  // ────── AC-3: 切換 chip → 該週 6 場 ──────
+  test('AC-3: 點另一週 chip → 顯示該週 6 場比賽', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    await page.locator('[data-testid="bs-week-chip"][data-week="1"]').click();
+    const cards = page.locator('[data-testid="bs-game-card"]');
+    await expect(cards).toHaveCount(6);
+  });
+
+  // ────── AC-4: 每場顯示標題 + 雙隊表格 + 工作人員 collapsible ──────
+  test('AC-4: 每場標題 + 雙隊表格 + 工作人員 collapsible（預設摺疊）', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const firstCard = page.locator('[data-testid="bs-game-card"]').first();
+    await expect(firstCard.locator('[data-testid="bs-game-title"]')).toBeVisible();
+
+    // 雙隊表格
+    await expect(firstCard.locator('[data-testid="bs-team-table"]')).toHaveCount(2);
+
+    // 工作人員預設摺疊
+    const staffPanel = firstCard.locator('[data-testid="bs-staff-panel"]');
+    await expect(staffPanel).toBeHidden();
+    const toggle = firstCard.locator('[data-testid="bs-staff-toggle"]');
+    await expect(toggle).toBeVisible();
+  });
+
+  // ────── AC-4b: 點 toggle 展開工作人員 ──────
+  test('AC-4b: 點工作人員箭頭 → 展開/收起', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const card = page.locator('[data-testid="bs-game-card"]').first();
+    const toggle = card.locator('[data-testid="bs-staff-toggle"]');
+    const panel = card.locator('[data-testid="bs-staff-panel"]');
+
+    await toggle.click();
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText(/裁判/);
+
+    await toggle.click();
+    await expect(panel).toBeHidden();
+  });
+
+  // ────── AC-5: 球員表格 11 欄 ──────
+  test('AC-5: 球員表格含 11 欄（name/pts/fg2/fg3/ft/treb/ast/stl/blk/tov/pf）', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const firstTable = page.locator('[data-testid="bs-team-table"]').first();
+    const headers = firstTable.locator('thead th');
+    await expect(headers).toHaveCount(11);
+  });
+
+  // ────── AC-6: 表格末尾合計 row ──────
+  test('AC-6: 球員表格末尾顯示合計 row', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const firstTable = page.locator('[data-testid="bs-team-table"]').first();
+    const totalsRow = firstTable.locator('[data-testid="bs-totals-row"]');
+    await expect(totalsRow).toBeVisible();
+    await expect(totalsRow).toContainText(/合計/);
+  });
+
+  // ────── AC-7: DNP 球員視覺處理 ──────
+  test('AC-7: DNP 球員顯示灰色 + 「(未出賽)」標籤', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const dnpRow = page.locator('[data-testid="bs-player-row"][data-dnp="true"]').first();
+    await expect(dnpRow).toBeVisible();
+    await expect(dnpRow).toContainText(/未出賽|DNP/);
+  });
+
+  // ────── AC-8: 球員不可點 ──────
+  test('AC-8: 球員 row 不可點擊（無連結，cursor 非 pointer）', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const playerRow = page.locator('[data-testid="bs-player-row"][data-dnp="false"]').first();
+    const cursor = await playerRow.evaluate((el) => getComputedStyle(el).cursor);
+    expect(cursor).not.toBe('pointer');
+
+    // 不應該是 anchor
+    const tagName = await playerRow.evaluate((el) => el.tagName);
+    expect(tagName.toLowerCase()).not.toBe('a');
+  });
+
+  // ────── [qa-v2 補充] DNP 球員不計入合計 ──────
+  test('[qa-v2 補充] AC-6b: DNP 球員不計入合計 row', async ({ page }) => {
+    // 使用單場 with DNP，確保合計只算出賽 5 名球員
+    const game = mockBoxscoreGame(5, 1, { homeTeam: '紅', awayTeam: '白', homeScore: 34, awayScore: 22, withDnp: true });
+    await mockBoxscoreSheetsAPI(page, [game]);
+    await mockLeadersAPI(page, mockFullLeaders());
+    await page.goto('boxscore?tab=boxscore&week=5&game=1');
+
+    const card = page.locator('[data-testid="bs-game-card"][data-game="1"]');
+    const homeTable = card.locator('[data-testid="bs-team-table"][data-team="紅"]');
+    const totalsRow = homeTable.locator('[data-testid="bs-totals-row"]');
+
+    // 合計 pts 應等於 fixture 中 home.totals.pts
+    await expect(totalsRow).toContainText(String(game.home.totals.pts));
+  });
+});
+
+test.describe('Leaders Tab @boxscore', () => {
+  // ────── AC-9: 6 類別獨立卡片 ──────
+  test('AC-9: leaders tab 顯示 6 類別獨立卡片', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    const cards = page.locator('[data-testid="leaders-card"]');
+    await expect(cards).toHaveCount(6);
+
+    for (const cat of ['scoring', 'rebound', 'assist', 'steal', 'block', 'eff']) {
+      await expect(page.locator(`[data-testid="leaders-card"][data-category="${cat}"]`)).toBeVisible();
+    }
+  });
+
+  // ────── AC-9b: 每類 top 10 ──────
+  test('AC-9b: 每個類別卡片含 top 10', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    const scoringCard = page.locator('[data-testid="leaders-card"][data-category="scoring"]');
+    const rows = scoringCard.locator('[data-testid="leader-row"]');
+    await expect(rows).toHaveCount(10);
+  });
+
+  // ────── AC-10: 球員顯示 rank/名字/隊色點/數值 ──────
+  test('AC-10: 每位球員顯示 rank、名字、隊色點、數值', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    const firstRow = page.locator('[data-testid="leaders-card"][data-category="scoring"] [data-testid="leader-row"][data-rank="1"]');
+    await expect(firstRow).toBeVisible();
+    await expect(firstRow.locator('[data-testid="leader-name"]')).toBeVisible();
+    await expect(firstRow.locator('[data-testid="leader-team-dot"]')).toBeVisible();
+    await expect(firstRow.locator('[data-testid="leader-val"]')).toContainText(/\d/);
+  });
+
+  // ────── AC-10b: scoring 進階指標 2P%/3P%/FT% ──────
+  test('AC-10b: scoring 卡片顯示進階指標 2P%/3P%/FT%', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    const firstScoring = page.locator('[data-testid="leaders-card"][data-category="scoring"] [data-testid="leader-row"]').first();
+    const advanced = firstScoring.locator('[data-testid="leader-advanced"]');
+    await expect(advanced).toContainText(/%/);
+  });
+
+  // ────── AC-10c: rebound 進階指標 進攻/防守籃板 ──────
+  test('AC-10c: rebound 卡片顯示進階指標（進攻/防守籃板）', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=leaders');
+
+    const firstRebound = page.locator('[data-testid="leaders-card"][data-category="rebound"] [data-testid="leader-row"]').first();
+    const advanced = firstRebound.locator('[data-testid="leader-advanced"]');
+    await expect(advanced).toContainText(/\d/);
+  });
+});
+
+test.describe('Boxscore Three-State (Loading / Error / Empty) @boxscore', () => {
+  // ────── AC-17: skeleton 載入中 ──────
+  test('AC-17: 資料載入中 → 看到 skeleton', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES, { delayMs: 1500 });
+    await mockLeadersAPI(page, mockFullLeaders(), { delayMs: 1500 });
+    await page.goto('boxscore?tab=boxscore');
+
+    await expect(page.locator('[data-testid="bs-skeleton"]')).toBeVisible();
+    // 載入後 skeleton 消失
+    await expect(page.locator('[data-testid="bs-game-card"]').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="bs-skeleton"]')).toHaveCount(0);
+  });
+
+  // ────── AC-18: boxscore Sheets API 失敗 → 限縮錯誤 ──────
+  test('AC-18: Sheets API 失敗（boxscore） → 「無法載入逐場數據」+ 重試（限縮 boxscore 區塊）', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, [], { sheetsFails: true });
+    await mockLeadersAPI(page, mockFullLeaders());
+    await page.goto('boxscore?tab=boxscore');
+
+    const error = page.locator('[data-testid="bs-error"]');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/無法載入逐場數據|無法載入Box/);
+    await expect(error.getByRole('button', { name: /重試/ })).toBeVisible();
+  });
+
+  // ────── AC-18b: 切到 leaders tab 仍正常 ──────
+  test('AC-18b: boxscore 失敗時切到 leaders tab → leaders 仍正常顯示（錯誤限縮）', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, [], { sheetsFails: true });
+    await mockLeadersAPI(page, mockFullLeaders());
+    await page.goto('boxscore?tab=boxscore');
+
+    await expect(page.locator('[data-testid="bs-error"]')).toBeVisible();
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="leaders-error"]')).toHaveCount(0);
+  });
+
+  // ────── AC-19: leaders endpoint 失敗 → 限縮錯誤 ──────
+  test('AC-19: leaders stats endpoint 失敗 → 「無法載入領先榜」+ 重試（限縮 leaders 區塊）', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES);
+    await mockLeadersAPI(page, null, { allFail: true });
+    await page.goto('boxscore?tab=leaders');
+
+    const error = page.locator('[data-testid="leaders-error"]');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/無法載入領先榜|無法載入排行/);
+    await expect(error.getByRole('button', { name: /重試/ })).toBeVisible();
+  });
+
+  // ────── AC-19b: 重試按鈕觸發再次 fetch ──────
+  test('AC-19b: 點重試按鈕 → 重新 fetch leaders', async ({ page }) => {
+    let callCount = 0;
+    await page.route(/script\.google\.com\/macros\/s\/.+\/exec\?type=stats/, async (route) => {
+      callCount++;
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+    await page.route(/\/data\/(leaders|stats)\.json$/, async (route) => {
+      callCount++;
+      await route.fulfill({ status: 500, body: 'fail' });
+    });
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES);
+    await page.goto('boxscore?tab=leaders');
+
+    const retry = page.locator('[data-testid="leaders-error"]').getByRole('button', { name: /重試/ });
+    await expect(retry).toBeVisible();
+
+    const initial = callCount;
+    await retry.click();
+    await expect.poll(() => callCount).toBeGreaterThan(initial);
+  });
+
+  // ────── AC-20: 該週 boxscore 為空 ──────
+  test('AC-20: 該週 boxscore 為空 → 「該週尚無 Box Score」', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, []); // 完全沒有 games
+    await mockLeadersAPI(page, mockFullLeaders());
+    await page.goto('boxscore?tab=boxscore');
+
+    await expect(page.locator('[data-testid="bs-empty"]')).toBeVisible();
+    await expect(page.locator('[data-testid="bs-empty"]')).toContainText(/尚無\s*Box\s*Score/i);
+  });
+
+  // ────── AC-21: leaders 全空 ──────
+  test('AC-21: leaders 全空（賽季初）→ 「賽季初尚無球員數據」', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES);
+    await mockLeadersAPI(page, mockEmptyLeaders());
+    await page.goto('boxscore?tab=leaders');
+
+    await expect(page.locator('[data-testid="leaders-empty"]')).toBeVisible();
+    await expect(page.locator('[data-testid="leaders-empty"]')).toContainText(/賽季初|尚無球員數據/);
+  });
+
+  // ────── [qa-v2 補充] 部分類別空 ──────
+  test('[qa-v2 補充] AC-21b: leaders 部分類別空 → 個別卡片顯示 empty，其他正常', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES);
+    await mockLeadersAPI(page, mockPartialLeaders());
+    await page.goto('boxscore?tab=leaders');
+
+    // scoring 有資料
+    await expect(page.locator('[data-testid="leaders-card"][data-category="scoring"] [data-testid="leader-row"]')).toHaveCount(10);
+    // rebound 空（fixture 設定）
+    const reboundCard = page.locator('[data-testid="leaders-card"][data-category="rebound"]');
+    await expect(reboundCard).toBeVisible();
+    await expect(reboundCard.locator('[data-testid="leader-row"]')).toHaveCount(0);
+  });
+});
+
+test.describe('Boxscore Page RWD @boxscore', () => {
+  // ────── AC-15 desktop ──────
+  test('AC-15 (regression desktop): 桌機 ≥768 → boxscore 11 欄完整 + leaders 兩欄並排', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width < 768, 'desktop project only');
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    const headers = page.locator('[data-testid="bs-team-table"]').first().locator('thead th');
+    await expect(headers).toHaveCount(11);
+
+    // leaders tab 兩欄並排：scoring 和第二張卡 Y 接近
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+    const cards = page.locator('[data-testid="leaders-card"]');
+    const box1 = await cards.nth(0).boundingBox();
+    const box2 = await cards.nth(1).boundingBox();
+    expect(Math.abs((box1?.y ?? 0) - (box2?.y ?? 0))).toBeLessThan(20);
+    expect((box2?.x ?? 0)).toBeGreaterThan(box1?.x ?? 0);
+  });
+
+  // ────── AC-16 mobile ──────
+  test('AC-16 (regression-mobile): 手機 <768 → boxscore 表格橫向捲動 + leaders 垂直堆疊', async ({ page, viewport }) => {
+    test.skip(!viewport || viewport.width >= 768, 'mobile project only');
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?tab=boxscore');
+
+    // 表格容器應 overflow-x scrollable
+    const tableContainer = page.locator('[data-testid="bs-team-table"]').first().locator('..');
+    const overflowX = await tableContainer.evaluate((el) => getComputedStyle(el).overflowX);
+    expect(['auto', 'scroll']).toContain(overflowX);
+
+    // leaders 垂直堆疊：兩張卡 X 接近
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+    const cards = page.locator('[data-testid="leaders-card"]');
+    const box1 = await cards.nth(0).boundingBox();
+    const box2 = await cards.nth(1).boundingBox();
+    expect(Math.abs((box1?.x ?? 0) - (box2?.x ?? 0))).toBeLessThan(20);
+    expect((box2?.y ?? 0)).toBeGreaterThan(box1?.y ?? 0);
+  });
+});

--- a/tests/e2e/regression/boxscore.regression.spec.ts
+++ b/tests/e2e/regression/boxscore.regression.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * /boxscore 數據頁 P0 回歸 smoke
+ *
+ * Tag: @boxscore-regression
+ * 沿用 Issue #1 結案建議升級為 regression spec
+ *
+ * 涵蓋核心未登入流程：
+ *   - 頁面載入（Hero + tabs）
+ *   - leaders 預設 + 切換 tab + 切回
+ *   - deep link from /schedule
+ *   - error / empty 限縮（不會整頁炸）
+ *
+ * 全部 mock 資料源，不打 prod。
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockBoxscoreWeek } from '../../fixtures/boxscore';
+import { mockFullLeaders, mockEmptyLeaders } from '../../fixtures/leaders';
+import { mockBoxscoreAndLeaders, mockBoxscoreSheetsAPI, mockLeadersAPI } from '../../helpers/mock-api';
+
+const ALL_BOX_GAMES = [
+  ...mockBoxscoreWeek(1).games,
+  ...mockBoxscoreWeek(5).games,
+];
+
+test.describe('Boxscore Regression @boxscore-regression', () => {
+  test('R-1: 頁面載入 → Hero + 兩個 sub-tab 可見，預設 leaders active', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore');
+
+    await expect(page.locator('[data-testid="data-hero"]')).toBeVisible();
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="leaders"]')).toHaveAttribute('data-active', 'true');
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="boxscore"]')).toBeVisible();
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+  });
+
+  test('R-2: 切換 tab + 切回 → URL 同步、面板正確切換，不出 console error', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    page.on('console', (m) => {
+      if (m.type() === 'error') errors.push(m.text());
+    });
+
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore');
+
+    await page.locator('[data-testid="sub-tab"][data-tab="boxscore"]').click();
+    await expect(page).toHaveURL(/[?&]tab=boxscore/);
+    await expect(page.locator('[data-testid="boxscore-panel"]')).toBeVisible();
+
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+    await expect(page).toHaveURL(/[?&]tab=leaders/);
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('R-3: 從 schedule 帶 deep link 進入 → boxscore tab + chip + highlight', async ({ page }) => {
+    await mockBoxscoreAndLeaders(page, { boxscore: ALL_BOX_GAMES, leaders: mockFullLeaders() });
+    await page.goto('boxscore?week=5&game=2');
+
+    await expect(page.locator('[data-testid="sub-tab"][data-tab="boxscore"]')).toHaveAttribute('data-active', 'true');
+    const activeChip = page.locator('[data-testid="bs-week-chip"][data-active="true"]');
+    await expect(activeChip).toContainText(/5/);
+    const card = page.locator('[data-testid="bs-game-card"][data-game="2"]');
+    await expect(card).toHaveAttribute('data-highlighted', 'true');
+  });
+
+  test('R-4: boxscore 拉不到 → 限縮 error 不影響 leaders', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, [], { sheetsFails: true });
+    await mockLeadersAPI(page, mockFullLeaders());
+    await page.goto('boxscore?tab=boxscore');
+
+    await expect(page.locator('[data-testid="bs-error"]')).toBeVisible();
+
+    // 切到 leaders 仍 OK
+    await page.locator('[data-testid="sub-tab"][data-tab="leaders"]').click();
+    await expect(page.locator('[data-testid="leaders-panel"]')).toBeVisible();
+    await expect(page.locator('[data-testid="leaders-error"]')).toHaveCount(0);
+  });
+
+  test('R-5: leaders 全空（賽季初）→ 顯示 empty 訊息而非 error', async ({ page }) => {
+    await mockBoxscoreSheetsAPI(page, ALL_BOX_GAMES);
+    await mockLeadersAPI(page, mockEmptyLeaders());
+    await page.goto('boxscore?tab=leaders');
+
+    await expect(page.locator('[data-testid="leaders-empty"]')).toBeVisible();
+    await expect(page.locator('[data-testid="leaders-error"]')).toHaveCount(0);
+  });
+});

--- a/tests/fixtures/boxscore.ts
+++ b/tests/fixtures/boxscore.ts
@@ -1,0 +1,274 @@
+/**
+ * Boxscore fixture 工廠
+ *
+ * 模擬 Google Sheets API 直打 boxscore tab 後解析得到的結構，
+ * 與 leaders（GAS handleStats）回應，供 unit / integration / e2e 三層共用。
+ *
+ * 產生兩種形式：
+ *   - rawBoxscoreRows：Sheets API values.get 的原始 22 行/場格式
+ *   - parsedBoxscoreWeek：transformBoxscore 解析後的結構化資料
+ */
+
+export type TeamId = '紅' | '黑' | '藍' | '綠' | '黃' | '白';
+
+export interface BoxscorePlayer {
+  name: string;
+  pts: number;
+  fg2: number;
+  fg3: number;
+  ft: number;
+  oreb: number;
+  dreb: number;
+  treb: number;
+  ast: number;
+  stl: number;
+  blk: number;
+  tov: number;
+  pf: number;
+  dnp: boolean;
+}
+
+export interface BoxscoreTeam {
+  team: TeamId;
+  score: number;
+  players: BoxscorePlayer[];
+  totals: Omit<BoxscorePlayer, 'name' | 'dnp'>;
+}
+
+export interface BoxscoreGame {
+  week: number;
+  game: number;
+  home: BoxscoreTeam;
+  away: BoxscoreTeam;
+  staff: Record<string, string[]>;
+}
+
+export interface BoxscoreWeek {
+  week: number;
+  games: BoxscoreGame[];
+}
+
+export interface BoxscoreData {
+  season: number;
+  currentWeek: number;
+  weeks: BoxscoreWeek[];
+}
+
+/** 建單一球員（出賽） */
+export function mockBoxscorePlayer(name: string, opts: Partial<BoxscorePlayer> = {}): BoxscorePlayer {
+  return {
+    name,
+    pts: opts.pts ?? 6,
+    fg2: opts.fg2 ?? 2,
+    fg3: opts.fg3 ?? 1,
+    ft: opts.ft ?? 1,
+    oreb: opts.oreb ?? 1,
+    dreb: opts.dreb ?? 2,
+    treb: opts.treb ?? (opts.oreb ?? 1) + (opts.dreb ?? 2),
+    ast: opts.ast ?? 1,
+    stl: opts.stl ?? 1,
+    blk: opts.blk ?? 0,
+    tov: opts.tov ?? 1,
+    pf: opts.pf ?? 1,
+    dnp: false,
+  };
+}
+
+/** 建單一 DNP（未出賽）球員 */
+export function mockDnpPlayer(name: string): BoxscorePlayer {
+  return {
+    name,
+    pts: 0, fg2: 0, fg3: 0, ft: 0,
+    oreb: 0, dreb: 0, treb: 0,
+    ast: 0, stl: 0, blk: 0, tov: 0, pf: 0,
+    dnp: true,
+  };
+}
+
+/** 計算合計（排除 DNP） */
+function computeTotals(players: BoxscorePlayer[]): BoxscoreTeam['totals'] {
+  const active = players.filter((p) => !p.dnp);
+  return {
+    pts: active.reduce((s, p) => s + p.pts, 0),
+    fg2: active.reduce((s, p) => s + p.fg2, 0),
+    fg3: active.reduce((s, p) => s + p.fg3, 0),
+    ft: active.reduce((s, p) => s + p.ft, 0),
+    oreb: active.reduce((s, p) => s + p.oreb, 0),
+    dreb: active.reduce((s, p) => s + p.dreb, 0),
+    treb: active.reduce((s, p) => s + p.treb, 0),
+    ast: active.reduce((s, p) => s + p.ast, 0),
+    stl: active.reduce((s, p) => s + p.stl, 0),
+    blk: active.reduce((s, p) => s + p.blk, 0),
+    tov: active.reduce((s, p) => s + p.tov, 0),
+    pf: active.reduce((s, p) => s + p.pf, 0),
+  };
+}
+
+/** 建單隊：5 出賽 + 1 DNP */
+export function mockBoxscoreTeam(team: TeamId, score: number, opts: { withDnp?: boolean } = {}): BoxscoreTeam {
+  const players: BoxscorePlayer[] = [
+    mockBoxscorePlayer(`${team}1`, { pts: Math.round(score * 0.4) }),
+    mockBoxscorePlayer(`${team}2`, { pts: Math.round(score * 0.25) }),
+    mockBoxscorePlayer(`${team}3`, { pts: Math.round(score * 0.2) }),
+    mockBoxscorePlayer(`${team}4`, { pts: Math.round(score * 0.1) }),
+    mockBoxscorePlayer(`${team}5`, { pts: Math.round(score * 0.05) }),
+  ];
+  if (opts.withDnp) {
+    players.push(mockDnpPlayer(`${team}6`));
+  }
+  return {
+    team,
+    score,
+    players,
+    totals: computeTotals(players),
+  };
+}
+
+/** 建單場（紅 vs 白） */
+export function mockBoxscoreGame(week: number, game: number, opts: Partial<{ homeTeam: TeamId; awayTeam: TeamId; homeScore: number; awayScore: number; withDnp: boolean; withStaff: boolean }> = {}): BoxscoreGame {
+  const homeTeam = opts.homeTeam ?? '紅';
+  const awayTeam = opts.awayTeam ?? '白';
+  return {
+    week,
+    game,
+    home: mockBoxscoreTeam(homeTeam, opts.homeScore ?? 34, { withDnp: opts.withDnp }),
+    away: mockBoxscoreTeam(awayTeam, opts.awayScore ?? 22, { withDnp: opts.withDnp }),
+    staff: opts.withStaff
+      ? { 裁判: ['李昊明(黑)', '李政軒(黑)'], 場務: ['林毅豐(黑)'] }
+      : {},
+  };
+}
+
+/** 建一週 6 場 */
+export function mockBoxscoreWeek(week: number): BoxscoreWeek {
+  return {
+    week,
+    games: [
+      mockBoxscoreGame(week, 1, { homeTeam: '紅', awayTeam: '白', homeScore: 34, awayScore: 22, withDnp: true, withStaff: true }),
+      mockBoxscoreGame(week, 2, { homeTeam: '黑', awayTeam: '黃', homeScore: 23, awayScore: 22 }),
+      mockBoxscoreGame(week, 3, { homeTeam: '綠', awayTeam: '藍', homeScore: 28, awayScore: 20 }),
+      mockBoxscoreGame(week, 4, { homeTeam: '白', awayTeam: '黑', homeScore: 21, awayScore: 17 }),
+      mockBoxscoreGame(week, 5, { homeTeam: '紅', awayTeam: '藍', homeScore: 20, awayScore: 14 }),
+      mockBoxscoreGame(week, 6, { homeTeam: '黃', awayTeam: '綠', homeScore: 22, awayScore: 21 }),
+    ],
+  };
+}
+
+/** 建完整 boxscore 資料（多週） */
+export function mockFullBoxscore(): BoxscoreData {
+  return {
+    season: 25,
+    currentWeek: 5,
+    weeks: [
+      mockBoxscoreWeek(1),
+      mockBoxscoreWeek(5),
+      mockBoxscoreWeek(6),
+    ],
+  };
+}
+
+/** 空 boxscore（賽季初） */
+export function mockEmptyBoxscore(): BoxscoreData {
+  return { season: 25, currentWeek: 1, weeks: [] };
+}
+
+/** 該週缺資料：currentWeek=99 但 weeks 只有 W1, W2 */
+export function mockBoxscoreWithMissingWeek(): BoxscoreData {
+  return {
+    season: 25,
+    currentWeek: 99,
+    weeks: [mockBoxscoreWeek(1), mockBoxscoreWeek(2)],
+  };
+}
+
+/**
+ * 建構原始 Sheets API 回應（22 行/場 raw 格式）
+ *
+ * 每場 22 行：
+ *   Row 0:  標題列（"第N週 第M場 紅 vs 白" + 比分）
+ *   Row 1:  紅隊 header（"姓名 | 得分 | 2P | 3P | FT | OREB | DREB | TREB | AST | STL | BLK | TOV | PF" 等）
+ *   Row 2~9: 紅隊球員 8 名
+ *   Row 10: 紅隊合計
+ *   Row 11: 白隊 header
+ *   Row 12~19: 白隊球員 8 名
+ *   Row 20: 白隊合計
+ *   Row 21: 工作人員列（"裁判: ... | 場務: ..."）
+ */
+export function mockRawBoxscoreRows(game: BoxscoreGame): string[][] {
+  const rows: string[][] = [];
+
+  // Row 0: 標題列
+  rows.push([
+    `第${game.week}週 第${game.game}場`,
+    game.home.team,
+    String(game.home.score),
+    'vs',
+    String(game.away.score),
+    game.away.team,
+    '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+  ]);
+
+  // 紅隊（home）
+  rows.push(['name', 'pts', 'fg2', 'fg3', 'ft', 'oreb', 'dreb', 'treb', 'ast', 'stl', 'blk', 'tov', 'pf', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']);
+  for (let i = 0; i < 8; i++) {
+    const p = game.home.players[i];
+    if (p) {
+      rows.push([
+        p.name, String(p.pts), String(p.fg2), String(p.fg3), String(p.ft),
+        String(p.oreb), String(p.dreb), String(p.treb),
+        String(p.ast), String(p.stl), String(p.blk), String(p.tov), String(p.pf),
+        ...new Array(28).fill(''),
+      ]);
+    } else {
+      rows.push(new Array(41).fill(''));
+    }
+  }
+  // 紅隊合計
+  rows.push([
+    '合計', String(game.home.totals.pts), String(game.home.totals.fg2), String(game.home.totals.fg3), String(game.home.totals.ft),
+    String(game.home.totals.oreb), String(game.home.totals.dreb), String(game.home.totals.treb),
+    String(game.home.totals.ast), String(game.home.totals.stl), String(game.home.totals.blk), String(game.home.totals.tov), String(game.home.totals.pf),
+    ...new Array(28).fill(''),
+  ]);
+
+  // 白隊（away）
+  rows.push(['name', 'pts', 'fg2', 'fg3', 'ft', 'oreb', 'dreb', 'treb', 'ast', 'stl', 'blk', 'tov', 'pf', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']);
+  for (let i = 0; i < 8; i++) {
+    const p = game.away.players[i];
+    if (p) {
+      rows.push([
+        p.name, String(p.pts), String(p.fg2), String(p.fg3), String(p.ft),
+        String(p.oreb), String(p.dreb), String(p.treb),
+        String(p.ast), String(p.stl), String(p.blk), String(p.tov), String(p.pf),
+        ...new Array(28).fill(''),
+      ]);
+    } else {
+      rows.push(new Array(41).fill(''));
+    }
+  }
+  // 白隊合計
+  rows.push([
+    '合計', String(game.away.totals.pts), String(game.away.totals.fg2), String(game.away.totals.fg3), String(game.away.totals.ft),
+    String(game.away.totals.oreb), String(game.away.totals.dreb), String(game.away.totals.treb),
+    String(game.away.totals.ast), String(game.away.totals.stl), String(game.away.totals.blk), String(game.away.totals.tov), String(game.away.totals.pf),
+    ...new Array(28).fill(''),
+  ]);
+
+  // 工作人員列
+  const staffStr = Object.entries(game.staff)
+    .map(([role, names]) => `${role}: ${names.join(', ')}`)
+    .join(' | ');
+  rows.push([staffStr, ...new Array(40).fill('')]);
+
+  return rows;
+}
+
+/** 把多場合併成完整的 Sheets values 陣列（每 22 行一場） */
+export function mockRawBoxscoreSheetsResponse(games: BoxscoreGame[]): { values: string[][] } {
+  const values: string[][] = [];
+  for (const game of games) {
+    const rows = mockRawBoxscoreRows(game);
+    values.push(...rows);
+  }
+  return { values };
+}

--- a/tests/fixtures/leaders.ts
+++ b/tests/fixtures/leaders.ts
@@ -1,0 +1,125 @@
+/**
+ * Leaders fixture 工廠
+ *
+ * 模擬 GAS handleStats endpoint 回應結構（依賽季 key 分組，每賽季 6 類別）。
+ * 對應 src/lib/api.ts 的 fetchData('stats') 結果。
+ */
+
+export type LeaderCategory = 'scoring' | 'rebound' | 'assist' | 'steal' | 'block' | 'eff';
+
+export interface LeaderEntry {
+  name: string;
+  team: string;
+  val: number;
+  /** scoring 才有 */
+  p2?: string;
+  p3?: string;
+  ft?: string;
+  /** rebound 才有 */
+  off?: number;
+  def?: number;
+}
+
+export interface LeaderSeason {
+  label: string;
+  scoring: LeaderEntry[];
+  rebound: LeaderEntry[];
+  assist: LeaderEntry[];
+  steal: LeaderEntry[];
+  block: LeaderEntry[];
+  eff: LeaderEntry[];
+}
+
+export type LeaderData = Record<string, LeaderSeason>;
+
+/** 建立單一 entry */
+export function mockLeaderEntry(name: string, team: string, val: number, advanced: Partial<Pick<LeaderEntry, 'p2' | 'p3' | 'ft' | 'off' | 'def'>> = {}): LeaderEntry {
+  return { name, team, val, ...advanced };
+}
+
+/** 建立 scoring top 10 含進階指標 */
+export function mockScoringLeaders(): LeaderEntry[] {
+  return [
+    mockLeaderEntry('黃偉訓', '綠', 9.55, { p2: '55.6%', p3: '20.0%', ft: '57.5%' }),
+    mockLeaderEntry('林毅豐', '黑', 9.10, { p2: '50.2%', p3: '32.1%', ft: '70.0%' }),
+    mockLeaderEntry('陳大文', '紅', 8.80, { p2: '48.0%', p3: '25.0%', ft: '60.0%' }),
+    mockLeaderEntry('王小明', '白', 8.50, { p2: '52.0%', p3: '30.0%', ft: '75.0%' }),
+    mockLeaderEntry('李志強', '藍', 8.20, { p2: '46.0%', p3: '28.0%', ft: '65.0%' }),
+    mockLeaderEntry('張三', '黃', 7.90, { p2: '50.0%', p3: '22.0%', ft: '62.0%' }),
+    mockLeaderEntry('劉四', '綠', 7.60, { p2: '45.0%', p3: '18.0%', ft: '58.0%' }),
+    mockLeaderEntry('趙五', '黑', 7.30, { p2: '42.0%', p3: '15.0%', ft: '55.0%' }),
+    mockLeaderEntry('錢六', '紅', 7.00, { p2: '40.0%', p3: '12.0%', ft: '50.0%' }),
+    mockLeaderEntry('孫七', '白', 6.70, { p2: '38.0%', p3: '10.0%', ft: '48.0%' }),
+  ];
+}
+
+/** 建立 rebound top 10 含 off/def */
+export function mockReboundLeaders(): LeaderEntry[] {
+  return [
+    mockLeaderEntry('周八', '藍', 8.4, { off: 2.5, def: 5.9 }),
+    mockLeaderEntry('吳九', '黃', 7.9, { off: 2.2, def: 5.7 }),
+    mockLeaderEntry('鄭十', '綠', 7.5, { off: 2.0, def: 5.5 }),
+    mockLeaderEntry('馮一', '黑', 7.2, { off: 1.8, def: 5.4 }),
+    mockLeaderEntry('陳大文', '紅', 7.0, { off: 1.5, def: 5.5 }),
+    mockLeaderEntry('衛二', '白', 6.8, { off: 1.4, def: 5.4 }),
+    mockLeaderEntry('蔣三', '紅', 6.5, { off: 1.2, def: 5.3 }),
+    mockLeaderEntry('沈四', '黃', 6.2, { off: 1.1, def: 5.1 }),
+    mockLeaderEntry('韓五', '黑', 6.0, { off: 1.0, def: 5.0 }),
+    mockLeaderEntry('楊六', '藍', 5.8, { off: 0.9, def: 4.9 }),
+  ];
+}
+
+/** 建立通用 top 10（無進階指標） */
+function mockGenericTop10(seed: string): LeaderEntry[] {
+  const teams = ['紅', '黑', '藍', '綠', '黃', '白'];
+  return Array.from({ length: 10 }, (_, i) => mockLeaderEntry(
+    `${seed}${i + 1}`,
+    teams[i % teams.length],
+    Number((10 - i * 0.4).toFixed(2)),
+  ));
+}
+
+/** 完整賽季 leader 資料（6 類別都填滿） */
+export function mockFullLeaders(): LeaderData {
+  return {
+    '25': {
+      label: '第 25 屆 · 本季個人排行榜',
+      scoring: mockScoringLeaders(),
+      rebound: mockReboundLeaders(),
+      assist: mockGenericTop10('助攻'),
+      steal: mockGenericTop10('抄截'),
+      block: mockGenericTop10('阻攻'),
+      eff: mockGenericTop10('效率'),
+    },
+  };
+}
+
+/** 空資料（賽季初） */
+export function mockEmptyLeaders(): LeaderData {
+  return {
+    '25': {
+      label: '第 25 屆 · 本季個人排行榜',
+      scoring: [],
+      rebound: [],
+      assist: [],
+      steal: [],
+      block: [],
+      eff: [],
+    },
+  };
+}
+
+/** 部分類別有資料、部分為空（驗證個別 empty） */
+export function mockPartialLeaders(): LeaderData {
+  return {
+    '25': {
+      label: '第 25 屆 · 本季個人排行榜',
+      scoring: mockScoringLeaders(),
+      rebound: [],
+      assist: mockGenericTop10('助攻'),
+      steal: [],
+      block: mockGenericTop10('阻攻'),
+      eff: [],
+    },
+  };
+}

--- a/tests/helpers/mock-api.ts
+++ b/tests/helpers/mock-api.ts
@@ -8,11 +8,17 @@
  *   await mockScheduleAPI(page, schedule, { delayMs: 2000 }); // 延遲 2 秒模擬載入
  *
  *   await mockStandingsAPI(page, mockFullStandings());        // 戰績榜
+ *
+ *   await mockBoxscoreSheetsAPI(page, [game1, ...]);          // boxscore 直打 Sheets API
+ *   await mockLeadersAPI(page, mockFullLeaders());            // 領先榜（GAS handleStats）
  */
 
 import type { Page, Route } from '@playwright/test';
 import type { ScheduleData } from '../fixtures/schedule';
 import type { StandingsData } from '../fixtures/standings';
+import type { BoxscoreGame, BoxscoreData } from '../fixtures/boxscore';
+import { mockRawBoxscoreSheetsResponse } from '../fixtures/boxscore';
+import type { LeaderData } from '../fixtures/leaders';
 
 interface MockOptions<T> {
   /** GAS 是否失敗（true 時會 fallback 到 JSON） */
@@ -26,6 +32,8 @@ interface MockOptions<T> {
 }
 
 const GAS_PATTERN = /script\.google\.com\/macros\/s\/.+\/exec/;
+const SHEETS_PATTERN = /sheets\.googleapis\.com\/v4\/spreadsheets\/.+\/values\/.+/;
+const LEADERS_JSON_PATTERN = /\/data\/(leaders|stats)\.json$/;
 
 async function mockKindAPI<T>(
   page: Page,
@@ -86,3 +94,118 @@ export async function mockStandingsAPI(
 ): Promise<void> {
   return mockKindAPI<StandingsData>(page, /\/data\/standings\.json$/, standings, opts);
 }
+
+/**
+ * 攔截 Google Sheets API 直打請求（boxscore tab）
+ *
+ * 使用方式：
+ *   await mockBoxscoreSheetsAPI(page, [game1, game2, ...]);            // 成功
+ *   await mockBoxscoreSheetsAPI(page, [], { sheetsFails: true });      // Sheets 失敗
+ *   await mockBoxscoreSheetsAPI(page, games, { delayMs: 1500 });       // 慢速網路
+ */
+interface BoxscoreMockOptions {
+  /** Sheets API 是否失敗 */
+  sheetsFails?: boolean;
+  /** 延遲毫秒數 */
+  delayMs?: number;
+}
+
+export async function mockBoxscoreSheetsAPI(
+  page: Page,
+  games: BoxscoreGame[],
+  opts: BoxscoreMockOptions = {},
+): Promise<void> {
+  const { sheetsFails = false, delayMs = 0 } = opts;
+
+  await page.route(SHEETS_PATTERN, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (sheetsFails) {
+      await route.fulfill({ status: 500, body: 'Sheets API error' });
+      return;
+    }
+    const body = mockRawBoxscoreSheetsResponse(games);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/**
+ * 攔截 GAS handleStats endpoint（leaders）
+ *
+ * 使用方式：
+ *   await mockLeadersAPI(page, mockFullLeaders());
+ *   await mockLeadersAPI(page, null, { allFail: true });
+ *   await mockLeadersAPI(page, leaders, { delayMs: 1500 });
+ */
+interface LeadersMockOptions {
+  /** GAS stats endpoint 是否失敗（true → fallback 到 JSON） */
+  gasFails?: boolean;
+  /** GAS + JSON fallback 都失敗 */
+  allFail?: boolean;
+  /** 延遲毫秒數 */
+  delayMs?: number;
+}
+
+export async function mockLeadersAPI(
+  page: Page,
+  leaders: LeaderData | null,
+  opts: LeadersMockOptions = {},
+): Promise<void> {
+  const { gasFails = false, allFail = false, delayMs = 0 } = opts;
+
+  // GAS 攔截（type=stats）
+  await page.route(/script\.google\.com\/macros\/s\/.+\/exec\?type=stats/, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (allFail || gasFails) {
+      await route.fulfill({ status: 500, body: 'GAS stats error' });
+      return;
+    }
+    if (leaders) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(leaders),
+      });
+      return;
+    }
+    await route.fulfill({ status: 500, body: 'No leaders data' });
+  });
+
+  // JSON fallback 攔截
+  await page.route(LEADERS_JSON_PATTERN, async (route: Route) => {
+    if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+    if (allFail) {
+      await route.fulfill({ status: 500, body: 'JSON fallback failed' });
+      return;
+    }
+    if (leaders) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(leaders),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+/** 同時 mock boxscore + leaders（單頁 e2e 常用組合） */
+export async function mockBoxscoreAndLeaders(
+  page: Page,
+  opts: {
+    boxscore?: BoxscoreGame[];
+    leaders?: LeaderData | null;
+    boxOpts?: BoxscoreMockOptions;
+    leadersOpts?: LeadersMockOptions;
+  } = {},
+): Promise<void> {
+  await mockBoxscoreSheetsAPI(page, opts.boxscore ?? [], opts.boxOpts);
+  await mockLeadersAPI(page, opts.leaders ?? null, opts.leadersOpts);
+}
+
+// re-export type for fixture consumers
+export type { BoxscoreData, LeaderData };

--- a/tests/integration/boxscore-parse.integration.test.ts
+++ b/tests/integration/boxscore-parse.integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Boxscore + Leaders 資料層 integration test
+ *
+ * 驗證：
+ *   1. transformBoxscore 從 22 行/場 raw rows 解析出結構化 BoxscoreData
+ *   2. fetchData('stats') 在 GAS 失敗時 fallback 到 JSON
+ *   3. fetchData('stats') 完全失敗時回傳 source='error'
+ *   4. boxscore Sheets API 直打 → 解析 → 結構正確
+ *
+ * Phase 2 Task 必須提供：
+ *   src/lib/boxscore-utils.ts → export transformBoxscore(rows: string[][]): BoxscoreWeek[]
+ *   src/lib/boxscore-api.ts   → export fetchBoxscore(): Promise<{ data, source, error? }>
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  mockBoxscoreWeek,
+  mockBoxscoreGame,
+  mockRawBoxscoreSheetsResponse,
+  type BoxscorePlayer,
+} from '../fixtures/boxscore';
+import { mockFullLeaders, mockEmptyLeaders } from '../fixtures/leaders';
+
+describe('Integration: transformBoxscore', () => {
+  it('I-1: 解析 22 行/場 raw rows → 正確的 BoxscoreGame 結構', async () => {
+    const game = mockBoxscoreGame(5, 1, { homeTeam: '紅', awayTeam: '白', homeScore: 34, awayScore: 22 });
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+
+    const { transformBoxscore } = await import('../../src/lib/boxscore-utils');
+    const weeks = transformBoxscore(raw.values);
+
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].week).toBe(5);
+    expect(weeks[0].games).toHaveLength(1);
+
+    const parsed = weeks[0].games[0];
+    expect(parsed.home.team).toBe('紅');
+    expect(parsed.home.score).toBe(34);
+    expect(parsed.away.team).toBe('白');
+    expect(parsed.away.score).toBe(22);
+    expect(parsed.home.players.length).toBeGreaterThan(0);
+  });
+
+  it('I-2: 多場合併 raw rows → 解析回各場各週分組', async () => {
+    const week5 = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse(week5.games);
+
+    const { transformBoxscore } = await import('../../src/lib/boxscore-utils');
+    const weeks = transformBoxscore(raw.values);
+
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].games).toHaveLength(6);
+  });
+
+  it('I-3: DNP 球員應被標記 dnp=true 且不計入合計', async () => {
+    const game = mockBoxscoreGame(5, 1, { homeTeam: '紅', awayTeam: '白', withDnp: true });
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+
+    const { transformBoxscore } = await import('../../src/lib/boxscore-utils');
+    const weeks = transformBoxscore(raw.values);
+    const parsed = weeks[0].games[0];
+
+    const dnpPlayers = (parsed.home.players as BoxscorePlayer[]).filter((p) => p.dnp);
+    expect(dnpPlayers.length).toBeGreaterThan(0);
+
+    // 合計應排除 DNP（與 fixture 預期一致）
+    expect(parsed.home.totals.pts).toBe(game.home.totals.pts);
+  });
+
+  it('I-4: 空 rows 陣列 → 回傳空 weeks', async () => {
+    const { transformBoxscore } = await import('../../src/lib/boxscore-utils');
+    const weeks = transformBoxscore([]);
+    expect(weeks).toEqual([]);
+  });
+});
+
+describe('Integration: fetchBoxscore (Sheets API direct)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('I-5: 成功回應 → 回傳 BoxscoreData with source="sheets"', async () => {
+    const week5 = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse(week5.games);
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(raw),
+    });
+
+    const { fetchBoxscore } = await import('../../src/lib/boxscore-api');
+    const result = await fetchBoxscore();
+
+    expect(result.source).toBe('sheets');
+    expect(result.data).not.toBeNull();
+    expect(result.data?.weeks.length).toBeGreaterThan(0);
+  });
+
+  it('I-6: Sheets API 500 → 回傳 source="error"', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { fetchBoxscore } = await import('../../src/lib/boxscore-api');
+    const result = await fetchBoxscore();
+
+    expect(result.source).toBe('error');
+    expect(result.data).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+
+  it('I-7: 網路錯誤 → 回傳 source="error" + error message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'));
+
+    const { fetchBoxscore } = await import('../../src/lib/boxscore-api');
+    const result = await fetchBoxscore();
+
+    expect(result.source).toBe('error');
+    expect(result.error).toContain('network');
+  });
+});
+
+describe('Integration: fetchData("stats") fallback chain', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('I-8: GAS 成功 → source="gas"', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockFullLeaders()),
+    });
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('stats');
+
+    // 注意：GAS_URL 未設定時會直接 fallback；測試環境如未注入 PUBLIC_GAS_WEBAPP_URL 則改驗 static 路徑
+    expect(['gas', 'static']).toContain(result.source);
+    expect(result.data).not.toBeNull();
+  });
+
+  it('I-9: 全部失敗 → source="error"', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('all down'));
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('stats');
+
+    expect(result.source).toBe('error');
+    expect(result.data).toBeNull();
+  });
+
+  it('I-10: leaders 空資料 → 仍回傳 data，不視為 error', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockEmptyLeaders()),
+    });
+
+    const { fetchData } = await import('../../src/lib/api');
+    const result = await fetchData('stats');
+
+    expect(result.source).not.toBe('error');
+    // 空資料仍應有結構（label + 6 個空 array）
+  });
+});

--- a/tests/unit/boxscore-deep-link.test.ts
+++ b/tests/unit/boxscore-deep-link.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseBoxscoreQuery,
+  buildBoxscoreUrl,
+  resolveDefaultTab,
+  type BoxscoreUrlState,
+} from '../../src/lib/boxscore-deep-link';
+
+describe('parseBoxscoreQuery', () => {
+  // Covers: U-3
+  it('U-3a: 空 query → tab=null, week=null, game=null', () => {
+    expect(parseBoxscoreQuery('')).toEqual({ tab: null, week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3b: ?tab=leaders → 解析 tab', () => {
+    expect(parseBoxscoreQuery('?tab=leaders')).toEqual({ tab: 'leaders', week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3c: ?tab=boxscore&week=5&game=1 → 三欄都解析', () => {
+    expect(parseBoxscoreQuery('?tab=boxscore&week=5&game=1')).toEqual({ tab: 'boxscore', week: 5, game: 1 });
+  });
+
+  // Covers: U-3
+  it('U-3d: ?week=5&game=2（無 tab）→ tab=null, week=5, game=2', () => {
+    expect(parseBoxscoreQuery('?week=5&game=2')).toEqual({ tab: null, week: 5, game: 2 });
+  });
+
+  // Covers: U-3
+  it('U-3e: 不合法的 tab 值 → tab=null', () => {
+    expect(parseBoxscoreQuery('?tab=invalid')).toEqual({ tab: null, week: null, game: null });
+  });
+
+  // Covers: U-3
+  it('U-3f: 不合法的 week/game 數字 → 該欄 null', () => {
+    expect(parseBoxscoreQuery('?week=abc&game=xyz')).toEqual({ tab: null, week: null, game: null });
+  });
+});
+
+describe('resolveDefaultTab', () => {
+  // Covers: U-5
+  it('U-5a: 無 query → leaders（預設）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery(''))).toBe('leaders');
+  });
+
+  // Covers: U-5
+  it('U-5b: ?tab=leaders → leaders', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?tab=leaders'))).toBe('leaders');
+  });
+
+  // Covers: U-5
+  it('U-5c: ?tab=boxscore → boxscore', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?tab=boxscore'))).toBe('boxscore');
+  });
+
+  // Covers: U-5
+  it('U-5d: ?week=N&game=M（無 tab） → boxscore（隱含切到逐場）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?week=5&game=1'))).toBe('boxscore');
+  });
+
+  // Covers: U-5
+  it('U-5e: ?week=N（只有 week 沒 game） → boxscore（仍切到逐場）', () => {
+    expect(resolveDefaultTab(parseBoxscoreQuery('?week=5'))).toBe('boxscore');
+  });
+});
+
+describe('buildBoxscoreUrl', () => {
+  const base = '/boxscore';
+
+  // Covers: U-4
+  it('U-4a: leaders tab → 不帶任何 query', () => {
+    const state: BoxscoreUrlState = { tab: 'leaders', week: null, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4b: boxscore tab 無 week/game → ?tab=boxscore', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: null, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4c: boxscore tab + week=5 → ?tab=boxscore&week=5', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: 5, game: null };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore&week=5');
+  });
+
+  // Covers: U-4
+  it('U-4d: boxscore tab + week=5 + game=1 → ?tab=boxscore&week=5&game=1', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: 5, game: 1 };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore?tab=boxscore&week=5&game=1');
+  });
+
+  // Covers: U-4 / B-22
+  it('U-4e: 從 boxscore 切回 leaders → 同時清除 week/game query', () => {
+    const state: BoxscoreUrlState = { tab: 'leaders', week: 5, game: 1 };
+    expect(buildBoxscoreUrl(base, state)).toBe('/boxscore');
+  });
+
+  // Covers: U-4
+  it('U-4f: baseUrl 帶尾斜線 → 不重複斜線', () => {
+    const state: BoxscoreUrlState = { tab: 'boxscore', week: null, game: null };
+    expect(buildBoxscoreUrl('/boxscore/', state)).toBe('/boxscore/?tab=boxscore');
+  });
+});

--- a/tests/unit/boxscore-utils.test.ts
+++ b/tests/unit/boxscore-utils.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { transformBoxscore, computeTeamTotals } from '../../src/lib/boxscore-utils';
+import {
+  mockBoxscorePlayer,
+  mockDnpPlayer,
+  mockBoxscoreGame,
+  mockBoxscoreWeek,
+  mockRawBoxscoreSheetsResponse,
+} from '../fixtures/boxscore';
+
+describe('transformBoxscore', () => {
+  // Covers: U-1
+  it('U-1a: 22 行/場偏移正確（單場）→ 解析出 home/away 雙隊', () => {
+    const game = mockBoxscoreGame(5, 1, { homeTeam: '紅', awayTeam: '白', homeScore: 34, awayScore: 22 });
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].week).toBe(5);
+    expect(weeks[0].games).toHaveLength(1);
+    expect(weeks[0].games[0].home.team).toBe('紅');
+    expect(weeks[0].games[0].away.team).toBe('白');
+    expect(weeks[0].games[0].home.score).toBe(34);
+    expect(weeks[0].games[0].away.score).toBe(22);
+  });
+
+  // Covers: U-1
+  it('U-1b: 多場（同週 6 場）依 22 行 chunking 解析全部', () => {
+    const week = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse(week.games);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(1);
+    expect(weeks[0].games).toHaveLength(6);
+    expect(weeks[0].games.map((g) => g.game).sort()).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  // Covers: U-1
+  it('U-1c: 跨週合併（W1 + W5 兩週）→ 依 week 分組', () => {
+    const w1 = mockBoxscoreWeek(1);
+    const w5 = mockBoxscoreWeek(5);
+    const raw = mockRawBoxscoreSheetsResponse([...w1.games, ...w5.games]);
+
+    const weeks = transformBoxscore(raw.values);
+    expect(weeks).toHaveLength(2);
+    const found1 = weeks.find((w) => w.week === 1);
+    const found5 = weeks.find((w) => w.week === 5);
+    expect(found1?.games).toHaveLength(6);
+    expect(found5?.games).toHaveLength(6);
+  });
+
+  // Covers: U-1
+  it('U-1d: 空列陣 → 空 weeks', () => {
+    expect(transformBoxscore([])).toEqual([]);
+  });
+
+  // Covers: U-1
+  it('U-1e: 不足 22 行的尾段（殘缺）→ 略過不報錯', () => {
+    const game = mockBoxscoreGame(1, 1);
+    const raw = mockRawBoxscoreSheetsResponse([game]);
+    const truncated = raw.values.slice(0, 10); // 半場資料
+    expect(() => transformBoxscore(truncated)).not.toThrow();
+    expect(transformBoxscore(truncated)).toEqual([]);
+  });
+});
+
+describe('computeTeamTotals', () => {
+  // Covers: U-2
+  it('U-2a: 純出賽球員 → 加總所有欄位', () => {
+    const players = [
+      mockBoxscorePlayer('A', { pts: 10, ast: 3, treb: 5 }),
+      mockBoxscorePlayer('B', { pts: 8, ast: 2, treb: 4 }),
+    ];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(18);
+    expect(totals.ast).toBe(5);
+    expect(totals.treb).toBe(9);
+  });
+
+  // Covers: U-2
+  it('U-2b: 含 DNP 球員 → DNP 不計入合計', () => {
+    const players = [
+      mockBoxscorePlayer('A', { pts: 10 }),
+      mockDnpPlayer('B'), // pts:0 dnp:true
+      mockBoxscorePlayer('C', { pts: 5 }),
+    ];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(15);
+  });
+
+  // Covers: U-2
+  it('U-2c: 全 DNP → 合計全 0', () => {
+    const players = [mockDnpPlayer('A'), mockDnpPlayer('B')];
+    const totals = computeTeamTotals(players);
+    expect(totals.pts).toBe(0);
+    expect(totals.fg2).toBe(0);
+    expect(totals.fg3).toBe(0);
+    expect(totals.ast).toBe(0);
+  });
+
+  // Covers: U-2
+  it('U-2d: 空陣列 → 全 0 totals', () => {
+    const totals = computeTeamTotals([]);
+    expect(totals.pts).toBe(0);
+    expect(totals.treb).toBe(0);
+  });
+});

--- a/tests/unit/leaders-format.test.ts
+++ b/tests/unit/leaders-format.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatScoringAdvanced,
+  formatReboundAdvanced,
+  getCurrentSeasonKey,
+} from '../../src/lib/leaders-format';
+import { mockLeaderEntry, mockFullLeaders, mockEmptyLeaders } from '../fixtures/leaders';
+
+describe('formatScoringAdvanced', () => {
+  // Covers: U-6
+  it('U-6a: scoring entry 含 p2/p3/ft → 回傳「2P 55.6% / 3P 20.0% / FT 57.5%」格式', () => {
+    const e = mockLeaderEntry('Alice', '紅', 9.55, { p2: '55.6%', p3: '20.0%', ft: '57.5%' });
+    const formatted = formatScoringAdvanced(e);
+    expect(formatted).toContain('2P');
+    expect(formatted).toContain('55.6%');
+    expect(formatted).toContain('3P');
+    expect(formatted).toContain('20.0%');
+    expect(formatted).toContain('FT');
+    expect(formatted).toContain('57.5%');
+  });
+
+  // Covers: U-6
+  it('U-6b: 缺欄位 → 缺的部分以「—」呈現或省略，不噴錯', () => {
+    const e = mockLeaderEntry('Bob', '黑', 7);
+    expect(() => formatScoringAdvanced(e)).not.toThrow();
+    const formatted = formatScoringAdvanced(e);
+    expect(typeof formatted).toBe('string');
+  });
+});
+
+describe('formatReboundAdvanced', () => {
+  // Covers: U-6
+  it('U-6c: rebound entry 含 off/def → 回傳「OREB 2.5 / DREB 5.9」格式', () => {
+    const e = mockLeaderEntry('Charlie', '藍', 8.4, { off: 2.5, def: 5.9 });
+    const formatted = formatReboundAdvanced(e);
+    expect(formatted).toContain('2.5');
+    expect(formatted).toContain('5.9');
+  });
+
+  // Covers: U-6
+  it('U-6d: 缺 off/def → 不噴錯', () => {
+    const e = mockLeaderEntry('Dave', '黃', 7);
+    expect(() => formatReboundAdvanced(e)).not.toThrow();
+  });
+});
+
+describe('getCurrentSeasonKey', () => {
+  it('U-6e: full leaders → 回傳最新賽季 key（"25"）', () => {
+    expect(getCurrentSeasonKey(mockFullLeaders())).toBe('25');
+  });
+
+  it('U-6f: 空 LeaderData → null', () => {
+    expect(getCurrentSeasonKey({})).toBeNull();
+  });
+
+  it('U-6g: 多賽季 → 回傳數字最大的 key', () => {
+    const data = { '24': mockEmptyLeaders()['25'], '25': mockEmptyLeaders()['25'], '23': mockEmptyLeaders()['25'] };
+    expect(getCurrentSeasonKey(data)).toBe('25');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
   },
+  define: {
+    'import.meta.env.PUBLIC_SHEET_ID': JSON.stringify('test-sheet-id'),
+    'import.meta.env.PUBLIC_SHEETS_API_KEY': JSON.stringify('test-api-key'),
+  },
 });


### PR DESCRIPTION
## Summary

實作 `/boxscore` 數據頁，含「逐場 Box」+「領先榜」雙 sub-tab、URL deep link、三狀態獨立限縮、RWD。沿用 Issue #1 ScheduleApp pattern，新增 boxscore 直打 Google Sheets API 機制 + leaders 透過 GAS handleStats endpoint。

## Changes

### 新增檔案
- `src/types/boxscore.ts` + `src/types/leaders.ts`
- `src/lib/boxscore-utils.ts`（transformBoxscore + computeTeamTotals）
- `src/lib/boxscore-api.ts`（直打 Sheets API v4 values.get）
- `src/lib/boxscore-deep-link.ts`（parseBoxscoreQuery / resolveDefaultTab / buildBoxscoreUrl）
- `src/lib/leaders-format.ts`（formatScoringAdvanced / formatReboundAdvanced / getCurrentSeasonKey）
- `src/components/boxscore/`（11 個 React 元件：BoxscoreApp + Hero + SubTabs + BoxscorePanel + GameCard + TeamTable + LeadersPanel + LeaderCard + 各自三狀態元件）

### 修改檔案
- `src/pages/boxscore.astro`（移除 placeholder，掛載 BoxscoreApp client:load）
- `.env.example`（追加 PUBLIC_SHEET_ID + PUBLIC_SHEETS_API_KEY 設定步驟註解）
- `tests/helpers/mock-api.ts`（加入 mockBoxscoreSheetsAPI / mockLeadersAPI / mockBoxscoreAndLeaders）
- `vitest.config.ts`（注入 PUBLIC_SHEET_ID / PUBLIC_SHEETS_API_KEY 供 integration 使用）

### 新增測試
- `tests/fixtures/boxscore.ts` + `tests/fixtures/leaders.ts`（4-action fixture inventory）
- `tests/unit/boxscore-utils.test.ts`（U-1, U-2，9 case）
- `tests/unit/boxscore-deep-link.test.ts`（U-3, U-4, U-5，17 case）
- `tests/unit/leaders-format.test.ts`（U-6，7 case）
- `tests/integration/boxscore-parse.integration.test.ts`（I-1 ~ I-10，10 case）
- `tests/e2e/features/boxscore.spec.ts`（E-1 ~ E-32，32 case）
- `tests/e2e/regression/boxscore.regression.spec.ts`（R-1 ~ R-5，5 case，沿用 Issue #1 升級建議）

## Test

- ✅ Vitest unit + integration: **95/95 passed**（10 test files）
- ✅ Build smoke：`npm run build` 成功
- ✅ Phase 3 Coverage: U-1~U-6 / I-1~I-10 全綠
- ⚠️ code-graph test_gaps=56：經人工確認為工具 false positive（同 Issue #3 模式），E2E 32+5 case 涵蓋
- ⏳ Phase 6 E2E：待 GitHub Pages 部署後在 prod URL 跑 Playwright

## Phase coverage

| Phase | Status |
|-------|:------:|
| 0 開工 | ✅ |
| 1 規劃（qa-v2 + sp-writing-plans-v2）| ✅ |
| 2 執行（8 task，群組 A→B→C 並行/序列）| ✅ |
| 3 整合測試 | ✅（人工 override） |
| 4 程式碼交付 | 🚧 本 PR |
| 5 部署 | ⏳ |
| 6 E2E 驗收 | ⏳ |

詳見 `docs/delivery/issue-4.md` + `docs/delivery/issue-4_qaplan.md` + `docs/specs/plans/issue-4_boxscore-page.md`