### PR TITLE
[L] feat(home): 首頁即時概覽 dashboard 實作 (#6)

### DIFF
--- a/docs/delivery/issue-6.md
+++ b/docs/delivery/issue-6.md
@@ -1,0 +1,60 @@
+# Issue #6 — [L] feature: / 首頁即時概覽 dashboard 實作
+
+**分級**：L  
+**START_SECONDS**：1777744176  
+**狀態**：進行中
+
+## Phase 0 開工
+
+- [x] 0.1 讀 Issue + 分級 [L]，上一個結案 #9（無升級 regression 標記）
+- [x] 0.2 建 worktree feat/6-home-dashboard → ../taan-basketball-league-issue-6
+- [x] 0.3 TaskCreate Phase Tasks（Task #1–7）
+
+## Phase 1 規劃
+
+- [x] 1.1 qa-v2 plan #6（含 fixture inventory）→ `issue-6_qaplan.md`
+- [x] 1.2 qa-v2 寫 E2E + integration test（5 spec files in tests/e2e/features/home/）
+- [x] 1.3 sp-writing-plans-v2 → `docs/specs/plans/2026-05-03-issue-6-home-dashboard.md` + `planned` label
+- [x] 1.4 Read plan，context 暫存：4 tasks，Group A(T1+T2並行)→B(T3)→C(T4)
+
+## Phase 2 執行
+
+- [x] Task 1：Types + Utils + Unit Tests（`0faa709`）— 104 tests pass
+- [x] Task 2：State Components Skeleton/Error/Empty（`e1c7b65`）
+- [x] Task 3：Content Components HeroBanner/Schedule/MiniStandings/MiniLeaders/MiniDragon（`a3ed314`）
+- [x] Task 4：HomeDashboard island + index.astro（`35a7607`）
+
+## Phase 3 整合測試
+
+**結果**：✅ PASSED（T3 誤判 override）
+
+| 項目 | 結果 |
+|------|------|
+| Unit + Integration tests | ✅ 104/104 PASS |
+| test_gaps（code-graph 報告）| 15（T3 類誤判，override 生效）|
+| 實際 test_gaps | 0 |
+
+**誤判 override 理由**（T3 類 — 第 3 次，instinct 已記錄）：
+- code-graph 缺口清單全為 React 顯示元件（EmptyState、ErrorState、HeroBanner、HomeDashboard、MiniDragon 等）
+- 這些元件由 `tests/e2e/features/home/` 5 個 spec 完整覆蓋（22 個 E2E case）
+- code-graph 只掃 Vitest，不讀 Playwright spec → 已知工具限制，非真實缺口
+- 本專案 pattern：React 顯示元件不寫 unit test（與 standings/schedule/boxscore 元件一致）
+- evolve-v2 確認：observations=3 → T3 類誤判已文件化，B-1 提案（改 qa-v2 Phase 3 流程）待使用者確認
+
+## Phase 4 程式碼交付
+
+- [ ] 4.1 commit + push feature branch
+- [ ] 4.2 建 PR
+- [ ] 4.3 merge to main
+
+## Phase 5 部署記錄
+
+<!-- 結果寫入此處 -->
+
+## Phase 6 E2E 驗收
+
+<!-- 結果寫入此處 -->
+
+## Metrics
+
+<!-- 結案後填入 -->

--- a/docs/delivery/issue-6_qaplan.md
+++ b/docs/delivery/issue-6_qaplan.md
@@ -1,0 +1,82 @@
+# Issue #6 QA Plan — 首頁即時概覽 Dashboard
+
+**平台偵測**：Web（Astro + Playwright）  
+**TG Bot 平台**：無
+
+---
+
+## Fixture Inventory
+
+| Entity | 動作 | 說明 |
+|--------|------|------|
+| HomeData | 補（新建 `tests/fixtures/home.ts`）| 全新 entity，結構與 home.json 一致 |
+| HomeStandingTeam (mini) | 補（包含於 home.ts）| home.json standings 與 standings.ts 結構不同（record 為字串非分開欄位）|
+| MiniStatCategory | 補（包含於 home.ts）| miniStats.pts/reb/ast 結構不同於 leaders.ts LeaderData |
+| DragonEntry (top 5) | 補（包含於 home.ts）| dragonTop10 結構獨立，不與 dragon 頁混用 |
+
+**Refactor Backlog（自動掃描，不在本 Issue 處理）**：
+- T2: Game / Leaders / Standings / Week 各有 3–5 個相似 factory，建議未來合併參數化
+
+**新建 mock-api helper**：`tests/helpers/mock-api/home.ts`（已補寫）  
+**更新**：`tests/helpers/mock-api/index.ts` 加 re-export  
+**環境變數**：`PUBLIC_GAS_WEBAPP_URL` 補寫至 `tests/environments.yml env_vars`（已補寫）
+
+---
+
+## Coverage Matrix
+
+| Coverage ID | B-ID | 行為 | 層 | 狀態 | 位置 |
+|-------------|------|------|-----|------|------|
+| E-1 | B-1 | Hero「TAAN BASKETBALL · 第 25 季」+ 副標「例行賽 · 第 3 週」| e2e | ❌→已補寫 | tests/e2e/features/home/home-hero-schedule.spec.ts |
+| E-2 | B-2 | 本週賽程區塊顯示日期 + 場地 | e2e | ❌→已補寫 | tests/e2e/features/home/home-hero-schedule.spec.ts |
+| E-3 | B-3 | 本週賽程 CTA 連 /schedule | e2e | ❌→已補寫 | tests/e2e/features/home/home-hero-schedule.spec.ts |
+| E-4 | B-4 | 戰績榜 6 隊迷你版（rank/隊色點+名/勝敗/勝率/連勝）| e2e | ❌→已補寫 | tests/e2e/features/home/home-standings.spec.ts |
+| E-5 | B-5 | 戰績榜 CTA 連 /standings | e2e | ❌→已補寫 | tests/e2e/features/home/home-standings.spec.ts |
+| E-6 | B-6 | 連勝 streakType=win → 橙字 + ↑ icon | e2e | ❌→已補寫 | tests/e2e/features/home/home-standings.spec.ts |
+| E-7 | B-7 | 連敗 streakType=lose → 紅字 + ↓ icon | e2e | ❌→已補寫 | tests/e2e/features/home/home-standings.spec.ts |
+| E-8 | B-8 | 領先榜 pts/reb/ast 各 top 3 並排顯示 | e2e | ❌→已補寫 | tests/e2e/features/home/home-leaders-dragon.spec.ts |
+| E-9 | B-9 | 領先榜 CTA 連 /boxscore?tab=leaders | e2e | ❌→已補寫 | tests/e2e/features/home/home-leaders-dragon.spec.ts |
+| E-10 | B-10 | 龍虎榜 top 5（rank/名/隊/總分）| e2e | ❌→已補寫 | tests/e2e/features/home/home-leaders-dragon.spec.ts |
+| E-11 | B-11 | 龍虎榜 CTA 連 /roster?tab=dragon | e2e | ❌→已補寫 | tests/e2e/features/home/home-leaders-dragon.spec.ts |
+| E-12 | B-13 | 點戰績榜隊伍列跳 /roster?team=<id> | e2e | ❌→已補寫 | tests/e2e/features/home/home-standings.spec.ts |
+| E-13 | B-14 | 手機（< 768px）各區塊垂直堆疊 | e2e | ❌→已補寫 | tests/e2e/features/home/home-rwd.spec.ts |
+| E-14 | B-15 | 桌機（≥ 768px）戰績榜+龍虎榜並排 | e2e | ❌→已補寫 | tests/e2e/features/home/home-rwd.spec.ts |
+| E-15 | B-16 | 桌機領先榜三指標橫排 | e2e | ❌→已補寫 | tests/e2e/features/home/home-rwd.spec.ts |
+| E-16 | B-17 | 資料載入中顯示 skeleton | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-17 | B-18 | GAS + JSON 全失敗 → 錯誤訊息 + 重試按鈕 | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-18 | B-19 | 點重試按鈕重新 fetch [qa-v2 補充] | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-19 | B-20 | home.json 空資料 → 「賽季尚未開始 ⛹️」| e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-20 | B-21 | streakType null → 不顯示 icon，只顯示文字 | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-21 | B-22 | players < 3 → 顯示現有，不報錯 | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| E-22 | B-23 | dragonTop10 < 5 → 顯示現有，不報錯 | e2e | ❌→已補寫 | tests/e2e/features/home/home-states.spec.ts |
+| U-1 | B-6/7 | getStreakClass(type) → win/lose 對應正確 class | unit | ⬜ Phase 2 | tests/unit/home-utils.test.ts |
+| U-2 | B-21 | streakType null/undefined → 不回傳 icon class | unit | ⬜ Phase 2 | tests/unit/home-utils.test.ts |
+| U-3 | B-22 | limitTop(players, 3) → length < 3 不報錯、回傳現有 | unit | ⬜ Phase 2 | tests/unit/home-utils.test.ts |
+| U-4 | B-23 | limitTop(dragon, 5) → length < 5 不報錯、回傳現有 | unit | ⬜ Phase 2 | tests/unit/home-utils.test.ts |
+| I-1 | B-2/4/8/10 | fetchData('home') GAS→fallback→error（通用路徑）| integration | ✅ 既有 | tests/integration/api-fallback.integration.test.ts |
+
+說明：I-1 標記「既有」是因為 api-fallback.integration.test.ts 已涵蓋所有 kind 的三層 fallback 邏輯（含 'home'），無需另建 home-specific integration test。
+
+---
+
+## Phase 3 執行清單（Integration）
+
+- ✅ 既有（涵蓋 home kind）：`tests/integration/api-fallback.integration.test.ts`
+- 新增 Unit：`tests/unit/home-utils.test.ts`（由 Phase 2 Task 建立）
+
+---
+
+## Phase 6 執行清單（E2E）
+
+- `tests/e2e/features/home/home-hero-schedule.spec.ts`（E-1, E-2, E-3）
+- `tests/e2e/features/home/home-standings.spec.ts`（E-4, E-5, E-6, E-7, E-12）
+- `tests/e2e/features/home/home-leaders-dragon.spec.ts`（E-8, E-9, E-10, E-11）
+- `tests/e2e/features/home/home-states.spec.ts`（E-16, E-17, E-18, E-19, E-20, E-21, E-22）
+- `tests/e2e/features/home/home-rwd.spec.ts`（E-13, E-14, E-15）
+- `tests/e2e/regression/` — P0 regression 套件（每次必跑）
+
+---
+
+## Regression Promotion 評估（Phase 6 結束後）
+
+`home.regression.spec.ts`（現有 smoke test）已在 regression 套件，確保首頁可載入的基本行為已列為 P0。

--- a/docs/specs/plans/2026-05-03-issue-6-home-dashboard.md
+++ b/docs/specs/plans/2026-05-03-issue-6-home-dashboard.md
@@ -1,0 +1,885 @@
+# 首頁即時概覽 Dashboard 實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 將首頁（`/`）從純導覽 grid 升級為 5 區塊 dashboard（Hero + 本週賽程 + 戰績榜迷你版 + 領先榜 + 龍虎榜），資料來源 `home.json`。
+
+**Architecture:** Astro island（`client:visible`），HomeDashboard.tsx 負責 state machine（loading/error/empty/ok），各區塊為純顯示子元件。沿用 ScheduleApp / StandingsApp 的 `fetchData` 三層 fallback + `reloadKey` retry 模式。
+
+**Tech Stack:** Astro 6 + React（island）、Tailwind CSS 4、TypeScript strict、Vitest（unit）、Playwright（E2E）
+
+**個人風格規則**：命中 2 條 — style-skeleton-loading, style-rwd-list
+
+**Code Graph**：圖未建立，跳過
+
+---
+
+## Coverage Matrix
+
+| qaplan ID | 描述 | 對應 Task | 覆蓋方式 |
+|-----------|------|-----------|---------|
+| U-1 | getStreakStyle win/lose → class + arrow | Task 1 Step 1 | unit test |
+| U-2 | getStreakStyle null → 無 arrow | Task 1 Step 1 | unit test |
+| U-3 | limitTop players < 3 不報錯 | Task 1 Step 1 | unit test |
+| U-4 | limitTop dragon < 5 不報錯 | Task 1 Step 1 | unit test |
+| I-1 | fetchData('home') 三層 fallback | — | ✅ 既有 tests/integration/api-fallback.integration.test.ts |
+| E-1~E-22 | 所有 E2E 案例 | — | tests/e2e/features/home/*.spec.ts（qa-v2 Phase 6）|
+
+---
+
+## Task 相依關係
+
+```
+Task 1（Types + Utils）
+  └─ Task 2（State Components）   ←─ 並行
+  └─ Task 3（Content Components）  ←─ 並行
+       └─ Task 4（Island + Page）
+```
+
+- Task 1 → Task 2, 3 並行
+- Task 4 等 Task 2 + Task 3 都完成後才執行
+
+---
+
+### Task 1：Types + Utils + Unit Tests
+
+**Files:**
+- Create: `src/types/home.ts`
+- Create: `src/lib/home-utils.ts`
+- Test: `tests/unit/home-utils.test.ts`
+
+## Style Rules
+
+無命中（純 TypeScript 工具函式，不涉及 UI 或非同步）
+
+- [ ] **Step 1：寫失敗測試（TDD）**
+
+```typescript
+// tests/unit/home-utils.test.ts
+import { describe, it, expect } from 'vitest';
+import { getStreakStyle, limitTop } from '../../src/lib/home-utils';
+
+describe('getStreakStyle', () => {
+  // Covers: U-1
+  it('win → 橙色 class + ↑ arrow', () => {
+    const result = getStreakStyle('win');
+    expect(result.arrow).toBe('↑');
+    expect(result.colorClass).toContain('orange');
+  });
+
+  it('lose → 紅色 class + ↓ arrow', () => {
+    const result = getStreakStyle('lose');
+    expect(result.arrow).toBe('↓');
+    expect(result.colorClass).toContain('red');
+  });
+
+  // Covers: U-2
+  it('null → arrow 為空字串（不顯示 icon）', () => {
+    const result = getStreakStyle(null);
+    expect(result.arrow).toBe('');
+  });
+
+  it('undefined-like null → colorClass 為中性色', () => {
+    const result = getStreakStyle(null);
+    expect(result.colorClass).not.toContain('orange');
+    expect(result.colorClass).not.toContain('red');
+  });
+});
+
+describe('limitTop', () => {
+  // Covers: U-3
+  it('超過指定數量時 slice', () => {
+    expect(limitTop([1, 2, 3, 4, 5], 3)).toEqual([1, 2, 3]);
+  });
+
+  it('剛好 3 筆不截斷', () => {
+    expect(limitTop([1, 2, 3], 3)).toEqual([1, 2, 3]);
+  });
+
+  // Covers: U-3, U-4
+  it('少於指定數量時回傳現有，不報錯', () => {
+    expect(limitTop([1], 3)).toEqual([1]);
+    expect(limitTop([], 5)).toEqual([]);
+  });
+
+  it('支援任意型別（object）', () => {
+    const items = [{ name: 'A' }, { name: 'B' }];
+    expect(limitTop(items, 5)).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2：確認測試失敗**
+
+```bash
+cd ../taan-basketball-league-issue-6 && npm test tests/unit/home-utils.test.ts
+```
+預期：FAIL — "Cannot find module '../../src/lib/home-utils'"
+
+- [ ] **Step 3：建立 `src/types/home.ts`**
+
+```typescript
+// src/types/home.ts
+export type HomeStreakType = 'win' | 'lose' | null;
+
+export interface MiniStatsPlayer {
+  rank: number;
+  name: string;
+  team: string;
+  val: number;
+}
+
+export interface MiniStatCategory {
+  label: string;
+  unit: string;
+  players: MiniStatsPlayer[];
+}
+
+export interface HomeStandingTeam {
+  rank: number;
+  name: string;
+  team: string;
+  record: string;
+  pct: string;
+  history: string[];
+  streak: string;
+  streakType: HomeStreakType;
+}
+
+export interface DragonEntry {
+  rank: number;
+  name: string;
+  team: string;
+  att: number;
+  duty: number;
+  total: number;
+}
+
+export interface HomeData {
+  season: number;
+  currentWeek: number;
+  phase: string;
+  scheduleInfo: {
+    date: string;
+    venue: string;
+  };
+  standings: HomeStandingTeam[];
+  dragonTop10: DragonEntry[];
+  miniStats: {
+    pts: MiniStatCategory;
+    reb: MiniStatCategory;
+    ast: MiniStatCategory;
+  };
+}
+```
+
+- [ ] **Step 4：建立 `src/lib/home-utils.ts`**
+
+```typescript
+// src/lib/home-utils.ts
+import type { HomeStreakType } from '../types/home';
+
+export interface StreakStyle {
+  colorClass: string;
+  arrow: '' | '↑' | '↓';
+}
+
+export function getStreakStyle(type: HomeStreakType): StreakStyle {
+  if (type === 'win') return { colorClass: 'text-orange', arrow: '↑' };
+  if (type === 'lose') return { colorClass: 'text-red-600', arrow: '↓' };
+  return { colorClass: 'text-txt-mid', arrow: '' };
+}
+
+/** slice 並在長度不足時安全回傳現有（不報錯，不補空白佔位） */
+export function limitTop<T>(arr: T[], n: number): T[] {
+  return arr.slice(0, n);
+}
+```
+
+- [ ] **Step 5：確認測試通過**
+
+```bash
+npm test tests/unit/home-utils.test.ts
+```
+預期：PASS（4 個 describe，8 個 test）
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add src/types/home.ts src/lib/home-utils.ts tests/unit/home-utils.test.ts
+git commit -m "feat(home): add HomeData types, home-utils (getStreakStyle, limitTop) (#6)"
+```
+
+---
+
+### Task 2：State Components（Skeleton / Error / Empty）
+
+**Files:**
+- Create: `src/components/home/SkeletonState.tsx`
+- Create: `src/components/home/ErrorState.tsx`
+- Create: `src/components/home/EmptyState.tsx`
+
+**依賴：** Task 1（僅共用 Tailwind design tokens，不依賴 home.ts types）
+
+## Style Rules（subagent 必讀）
+
+### style-skeleton-loading（命中原因：home dashboard 有非同步 fetch）
+
+**禁止：**
+- ❌ 整頁 spinner 擋住視口
+- ❌ 頁面空白等資料
+- ❌ `opacity-0` 隱藏內容直到 JS 執行完
+
+**正確做法：** 元件內 skeleton state，`status === "loading"` 時回傳 skeleton component（不回傳空白或 spinner）
+
+```tsx
+if (status === "loading") return <HomeSkeleton />;
+
+function HomeSkeleton() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse" data-testid="home-skeleton">
+      {/* Hero skeleton */}
+      <div className="h-10 w-48 bg-gray-200 rounded mx-auto mb-2" />
+      <div className="h-5 w-32 bg-gray-200 rounded mx-auto mb-8" />
+      {/* 4 區塊灰塊 */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-32 bg-gray-200 rounded-2xl mb-4" />
+      ))}
+    </div>
+  );
+}
+```
+
+Skeleton 形狀對應真實內容（Hero 長條 + 4 區塊），`animate-pulse`，不用文字說明。
+
+- [ ] **Step 1：建立 `src/components/home/SkeletonState.tsx`**
+
+```tsx
+// src/components/home/SkeletonState.tsx
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse" data-testid="home-skeleton">
+      {/* Hero */}
+      <div className="text-center mb-8">
+        <div className="h-10 w-48 bg-gray-200 rounded mx-auto mb-2" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+      {/* 4 區塊 */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-32 bg-gray-200 rounded-2xl mb-4" />
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2：建立 `src/components/home/ErrorState.tsx`**
+
+```tsx
+// src/components/home/ErrorState.tsx
+interface Props {
+  onRetry: () => void;
+}
+
+export function ErrorState({ onRetry }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center" data-testid="home-error">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入聯盟資訊</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3：建立 `src/components/home/EmptyState.tsx`**
+
+```tsx
+// src/components/home/EmptyState.tsx
+export function EmptyState() {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center" data-testid="home-empty">
+      <p className="text-lg text-txt-dark">賽季尚未開始 ⛹️</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4：Commit**
+
+```bash
+git add src/components/home/
+git commit -m "feat(home): add Skeleton/Error/Empty state components (#6)"
+```
+
+---
+
+### Task 3：Content Section Components
+
+**Files:**
+- Create: `src/components/home/HeroBanner.tsx`
+- Create: `src/components/home/ScheduleBlock.tsx`
+- Create: `src/components/home/MiniStandings.tsx`
+- Create: `src/components/home/MiniLeaders.tsx`
+- Create: `src/components/home/MiniDragon.tsx`
+
+**依賴：** Task 1（`src/types/home.ts`、`src/lib/home-utils.ts`）
+
+## Style Rules（subagent 必讀）
+
+### style-skeleton-loading（命中：有 fetch data 展示）
+
+子元件為純顯示（pure display），不做 fetch，不需要 skeleton。Skeleton 由父元件（HomeDashboard）統一控制。子元件僅接收已有資料的 props 並渲染。
+
+### style-rwd-list（命中：MiniStandings 5 個欄位，MiniDragon 4 欄位）
+
+**MiniStandings：**
+- PC（md 以上）：table 橫排（rank / 隊色點+名 / 勝敗 / 勝率 / 連勝）
+
+```tsx
+<div className="hidden md:block">
+  <table className="w-full">...</table>
+</div>
+```
+
+- Mobile（md 以下）：compact 每行一張卡片（rank + 隊名 + 勝敗 + 連勝）
+
+```tsx
+<div className="md:hidden space-y-2">
+  {teams.map(team => (
+    <a key={team.team} ...>
+      <div className="flex items-center justify-between">
+        <span>#{team.rank} {teamDot} {team.name}</span>
+        <span>{team.record}</span>
+        <StreakLabel team={team} />
+      </div>
+    </a>
+  ))}
+</div>
+```
+
+**MiniDragon：** 4 個欄位（rank / 名 / 隊 / 總分）
+- PC：table 橫排
+- Mobile：每行 flex row（rank + 名 + 隊色 + 總分）
+
+- [ ] **Step 1：建立 `src/components/home/HeroBanner.tsx`**
+
+```tsx
+// src/components/home/HeroBanner.tsx
+import type { HomeData } from '../../types/home';
+
+interface Props {
+  season: HomeData['season'];
+  phase: HomeData['phase'];
+  currentWeek: HomeData['currentWeek'];
+}
+
+export function HeroBanner({ season, phase, currentWeek }: Props) {
+  return (
+    <header className="text-center mb-8">
+      <h1 className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        TAAN BASKETBALL
+      </h1>
+      <p className="font-display text-xl text-navy tracking-wide">
+        第 {season} 季
+      </p>
+      <p className="text-txt-mid text-sm mt-1">
+        {phase} · 第 {currentWeek} 週
+      </p>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2：建立 `src/components/home/ScheduleBlock.tsx`**
+
+```tsx
+// src/components/home/ScheduleBlock.tsx
+import type { HomeData } from '../../types/home';
+
+interface Props {
+  scheduleInfo: HomeData['scheduleInfo'];
+  baseUrl: string;
+}
+
+export function ScheduleBlock({ scheduleInfo, baseUrl }: Props) {
+  const href = `${baseUrl.replace(/\/$/, '')}/schedule`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-schedule"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-2">📅 本週賽程</h2>
+      <p className="text-txt-dark mb-1">
+        下次比賽：{scheduleInfo.date}
+      </p>
+      <p className="text-txt-mid text-sm mb-3">📍 {scheduleInfo.venue}</p>
+      <a
+        href={href}
+        className="inline-block text-sm font-bold text-orange hover:underline"
+      >
+        看本週對戰 →
+      </a>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3：建立 `src/components/home/MiniStandings.tsx`**
+
+```tsx
+// src/components/home/MiniStandings.tsx
+import type { HomeStandingTeam } from '../../types/home';
+import { getStreakStyle } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  teams: HomeStandingTeam[];
+  baseUrl: string;
+}
+
+function teamDotStyle(teamId: string) {
+  const config = TEAM_CONFIG[teamId];
+  return { backgroundColor: config?.color ?? '#999' };
+}
+
+function buildRosterHref(baseUrl: string, teamId: string) {
+  const config = TEAM_CONFIG[teamId];
+  return `${baseUrl.replace(/\/$/, '')}/roster?team=${config?.id ?? teamId}`;
+}
+
+function StreakCell({ team }: { team: HomeStandingTeam }) {
+  const { colorClass, arrow } = getStreakStyle(team.streakType);
+  return (
+    <span
+      data-testid="streak"
+      data-streak-type={team.streakType ?? ''}
+      className={`font-condensed text-sm ${colorClass}`}
+    >
+      {team.streak}
+      {arrow
+        ? <span data-testid="streak-icon" aria-hidden="true"> {arrow}</span>
+        : null
+      }
+    </span>
+  );
+}
+
+export function MiniStandings({ teams, baseUrl }: Props) {
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-standings"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">🏆 戰績榜</h2>
+
+      {/* Mobile：compact card rows */}
+      <div className="md:hidden space-y-2">
+        {teams.map((team) => (
+          <a
+            key={team.team}
+            href={buildRosterHref(baseUrl, team.team)}
+            data-testid="home-standings-row"
+            className="flex items-center justify-between py-1.5 border-b border-warm-1 last:border-0 hover:bg-warm-1 rounded px-1 transition"
+            aria-label={`${team.name} 第 ${team.rank} 名`}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span data-testid="rank" className="text-xs text-txt-mid w-4 shrink-0">{team.rank}</span>
+              <span data-testid="team-dot" className="w-2.5 h-2.5 rounded-full shrink-0" style={teamDotStyle(team.team)} />
+              <span data-testid="team-name" className="font-bold text-sm text-navy truncate">{team.name}</span>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <span data-testid="record" className="text-xs text-txt-mid">{team.record}</span>
+              <StreakCell team={team} />
+            </div>
+          </a>
+        ))}
+      </div>
+
+      {/* Desktop：table */}
+      <div className="hidden md:block">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-txt-mid border-b border-warm-2">
+              <th className="text-left py-1 w-6">#</th>
+              <th className="text-left py-1">隊伍</th>
+              <th className="text-left py-1">勝敗</th>
+              <th className="text-left py-1">勝率</th>
+              <th className="text-left py-1">連勝</th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team) => (
+              <tr
+                key={team.team}
+                data-testid="home-standings-row"
+                className="border-b border-warm-1 last:border-0 hover:bg-warm-1 transition"
+              >
+                <td className="py-1.5"><span data-testid="rank" className="text-txt-mid">{team.rank}</span></td>
+                <td className="py-1.5">
+                  <a
+                    href={buildRosterHref(baseUrl, team.team)}
+                    className="flex items-center gap-1.5 hover:text-orange"
+                  >
+                    <span data-testid="team-dot" className="w-2.5 h-2.5 rounded-full" style={teamDotStyle(team.team)} />
+                    <span data-testid="team-name" className="font-bold text-navy">{team.name}</span>
+                  </a>
+                </td>
+                <td className="py-1.5"><span data-testid="record">{team.record}</span></td>
+                <td className="py-1.5"><span data-testid="pct">{team.pct}</span></td>
+                <td className="py-1.5"><StreakCell team={team} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 text-right">
+        <a
+          href={`${baseUrl.replace(/\/$/, '')}/standings`}
+          className="text-sm font-bold text-orange hover:underline"
+        >
+          看完整戰績 →
+        </a>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4：建立 `src/components/home/MiniLeaders.tsx`**
+
+```tsx
+// src/components/home/MiniLeaders.tsx
+import type { MiniStatCategory } from '../../types/home';
+import { limitTop } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  miniStats: { pts: MiniStatCategory; reb: MiniStatCategory; ast: MiniStatCategory };
+  baseUrl: string;
+}
+
+function StatCategory({ cat }: { cat: MiniStatCategory }) {
+  const top3 = limitTop(cat.players, 3);
+  return (
+    <div className="flex-1 min-w-0" data-testid="leader-category">
+      <h3 className="text-xs font-bold text-txt-mid mb-2 uppercase tracking-wide">
+        {cat.label} {cat.unit}
+      </h3>
+      <div className="space-y-1">
+        {top3.map((player) => {
+          const color = TEAM_CONFIG[player.team]?.color ?? '#999';
+          return (
+            <div key={`${player.name}-${player.rank}`} className="flex items-center gap-1.5" data-testid="leader-entry">
+              <span className="text-xs text-txt-mid w-4">{player.rank}</span>
+              <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+              <span data-testid="leader-name" className="text-sm font-bold text-navy truncate flex-1">{player.name}</span>
+              <span className="text-sm text-orange font-condensed shrink-0">{player.val}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function MiniLeaders({ miniStats, baseUrl }: Props) {
+  const href = `${baseUrl.replace(/\/$/, '')}/boxscore?tab=leaders`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-leaders"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">📊 領先榜</h2>
+      {/* 三指標橫排（md 以上），直排（mobile）*/}
+      <div className="flex flex-col md:flex-row gap-4">
+        <StatCategory cat={miniStats.pts} />
+        <StatCategory cat={miniStats.reb} />
+        <StatCategory cat={miniStats.ast} />
+      </div>
+      <div className="mt-3 text-right">
+        <a href={href} className="text-sm font-bold text-orange hover:underline">
+          看完整領先榜 →
+        </a>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5：建立 `src/components/home/MiniDragon.tsx`**
+
+```tsx
+// src/components/home/MiniDragon.tsx
+import type { DragonEntry } from '../../types/home';
+import { limitTop } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  dragonTop10: DragonEntry[];
+  baseUrl: string;
+}
+
+export function MiniDragon({ dragonTop10, baseUrl }: Props) {
+  const top5 = limitTop(dragonTop10, 5);
+  const href = `${baseUrl.replace(/\/$/, '')}/roster?tab=dragon`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-dragon"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">🐉 龍虎榜</h2>
+
+      {/* Mobile：compact rows */}
+      <div className="md:hidden space-y-2">
+        {top5.map((entry) => {
+          const color = TEAM_CONFIG[entry.team]?.color ?? '#999';
+          return (
+            <div key={entry.rank} data-testid="dragon-row" className="flex items-center gap-2 border-b border-warm-1 last:border-0 py-1.5">
+              <span data-testid="rank" className="text-xs text-txt-mid w-4">{entry.rank}</span>
+              <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: color }} />
+              <span data-testid="name" className="font-bold text-sm text-navy flex-1">{entry.name}</span>
+              <span data-testid="team" className="text-xs text-txt-mid">{entry.team}</span>
+              <span data-testid="total" className="text-sm font-condensed text-orange">{entry.total}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Desktop：table */}
+      <div className="hidden md:block">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-txt-mid border-b border-warm-2">
+              <th className="text-left py-1 w-6">#</th>
+              <th className="text-left py-1">名</th>
+              <th className="text-left py-1">隊</th>
+              <th className="text-right py-1">總分</th>
+            </tr>
+          </thead>
+          <tbody>
+            {top5.map((entry) => {
+              const color = TEAM_CONFIG[entry.team]?.color ?? '#999';
+              return (
+                <tr key={entry.rank} data-testid="dragon-row" className="border-b border-warm-1 last:border-0">
+                  <td className="py-1.5"><span data-testid="rank" className="text-txt-mid">{entry.rank}</span></td>
+                  <td className="py-1.5">
+                    <div className="flex items-center gap-1.5">
+                      <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
+                      <span data-testid="name" className="font-bold text-navy">{entry.name}</span>
+                    </div>
+                  </td>
+                  <td className="py-1.5"><span data-testid="team">{entry.team}</span></td>
+                  <td className="py-1.5 text-right"><span data-testid="total" className="text-orange font-condensed">{entry.total}</span></td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 text-right">
+        <a href={href} className="text-sm font-bold text-orange hover:underline">
+          看完整龍虎榜 →
+        </a>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 6：Commit**
+
+```bash
+git add src/components/home/
+git commit -m "feat(home): add Hero/Schedule/MiniStandings/MiniLeaders/MiniDragon components (#6)"
+```
+
+---
+
+### Task 4：HomeDashboard Island + index.astro 整合
+
+**Files:**
+- Create: `src/components/home/HomeDashboard.tsx`
+- Modify: `src/pages/index.astro`
+
+**依賴：** Task 2（SkeletonState, ErrorState, EmptyState）、Task 3（所有 Content Components）
+
+## Style Rules（subagent 必讀）
+
+### style-skeleton-loading（命中：HomeDashboard 有非同步 fetch）
+
+**禁止：**
+- ❌ 整頁 spinner 擋住視口
+- ❌ 頁面空白等資料
+- ❌ `opacity-0` 隱藏到 JS 執行完
+
+**正確做法：** `status === "loading"` → 回傳 `<SkeletonState />`（已在 Task 2 實作，形狀對應 4 個區塊），不回傳空白。
+
+沿用 StandingsApp / ScheduleApp 的 state machine 模式：
+
+```tsx
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+const [status, setStatus] = useState<Status>('loading');
+const [reloadKey, setReloadKey] = useState(0);
+// useEffect 監聽 reloadKey，handleRetry = setReloadKey((k) => k + 1)
+```
+
+### style-rwd-list（命中：dashboard 含多欄位列表區塊）
+
+主 layout 規則（HomeDashboard 層面）：
+- 戰績榜 + 龍虎榜：mobile 垂直堆疊，desktop 並排兩欄
+- 領先榜：mobile 直排，desktop 三欄橫排（由 MiniLeaders 內部 flex 處理）
+
+```tsx
+{/* 桌機：戰績榜 + 龍虎榜並排 */}
+<div className="md:grid md:grid-cols-2 md:gap-4">
+  <MiniStandings teams={teams} baseUrl={baseUrl} />
+  <MiniDragon dragonTop10={data.dragonTop10} baseUrl={baseUrl} />
+</div>
+```
+
+- [ ] **Step 1：建立 `src/components/home/HomeDashboard.tsx`**
+
+```tsx
+// src/components/home/HomeDashboard.tsx
+import { useEffect, useState, useCallback } from 'react';
+import type { HomeData } from '../../types/home';
+import { fetchData } from '../../lib/api';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { HeroBanner } from './HeroBanner';
+import { ScheduleBlock } from './ScheduleBlock';
+import { MiniStandings } from './MiniStandings';
+import { MiniLeaders } from './MiniLeaders';
+import { MiniDragon } from './MiniDragon';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function HomeDashboard({ baseUrl }: Props) {
+  const [data, setData] = useState<HomeData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<HomeData>('home');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const home = result.data;
+      setData(home);
+
+      const hasData =
+        home.standings?.length > 0 ||
+        home.dragonTop10?.length > 0;
+
+      if (!hasData) {
+        setStatus('empty');
+        return;
+      }
+
+      setStatus('ok');
+    })();
+
+    return () => { cancelled = true; };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <EmptyState />;
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 md:px-8 pb-8" data-testid="home-dashboard">
+      <HeroBanner
+        season={data.season}
+        phase={data.phase}
+        currentWeek={data.currentWeek}
+      />
+
+      <ScheduleBlock scheduleInfo={data.scheduleInfo} baseUrl={baseUrl} />
+
+      <MiniLeaders miniStats={data.miniStats} baseUrl={baseUrl} />
+
+      {/* 戰績榜 + 龍虎榜：mobile 垂直堆疊、desktop 並排兩欄 */}
+      <div className="md:grid md:grid-cols-2 md:gap-4">
+        <MiniStandings teams={data.standings} baseUrl={baseUrl} />
+        <MiniDragon dragonTop10={data.dragonTop10} baseUrl={baseUrl} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2：修改 `src/pages/index.astro`**
+
+```astro
+---
+import Layout from '../layouts/Layout.astro';
+import { HomeDashboard } from '../components/home/HomeDashboard';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<Layout title="首頁" active="home">
+  <HomeDashboard client:visible baseUrl={baseUrl} />
+</Layout>
+```
+
+（移除舊的 nav grid HTML）
+
+- [ ] **Step 3：本機驗證**
+
+```bash
+npm run dev
+# 瀏覽 http://localhost:4321/taan-basketball-league/
+# 確認：Hero + 賽程 + 領先榜 + 戰績/龍虎榜並排
+```
+
+- [ ] **Step 4：跑全部 unit tests**
+
+```bash
+npm test
+```
+預期：所有既有 unit tests + home-utils.test.ts 全 PASS
+
+- [ ] **Step 5：Commit**
+
+```bash
+git add src/components/home/HomeDashboard.tsx src/pages/index.astro
+git commit -m "feat(home): implement HomeDashboard island + integrate index.astro (#6)"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] AC-1~17 每條都有對應 Task + E2E spec
+- [x] 無 TBD / TODO / "Similar to Task N" 佔位符
+- [x] 整合測試走 api-fallback 真實路徑（既有 ✅）
+- [x] Unit tests 驗回傳值，非 assert_called
+- [x] style-skeleton-loading 遵從：Task 4 status=loading → SkeletonState，不空白
+- [x] style-rwd-list 遵從：MiniStandings + MiniDragon 各有 md:hidden / hidden md:block 雙呈現
+- [x] data-testid 與 E2E spec 一致（home-dashboard, home-standings-row, streak-icon, leader-entry, dragon-row, ...）
+- [x] baseUrl 透過 props 傳入 island，不在元件內直接讀 import.meta.env

--- a/src/components/home/EmptyState.tsx
+++ b/src/components/home/EmptyState.tsx
@@ -1,0 +1,7 @@
+export function EmptyState() {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center" data-testid="home-empty">
+      <p className="text-lg text-txt-dark">賽季尚未開始 ⛹️</p>
+    </div>
+  );
+}

--- a/src/components/home/ErrorState.tsx
+++ b/src/components/home/ErrorState.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  onRetry: () => void;
+}
+
+export function ErrorState({ onRetry }: Props) {
+  return (
+    <div className="px-4 py-12 max-w-md mx-auto text-center" data-testid="home-error">
+      <div className="text-5xl mb-4" aria-hidden="true">⚠️</div>
+      <p className="text-lg text-txt-dark mb-2">無法載入聯盟資訊</p>
+      <p className="text-sm text-txt-mid mb-6">請檢查網路連線或稍後再試</p>
+      <button
+        onClick={onRetry}
+        className="px-6 py-2 bg-orange text-white rounded-lg font-bold hover:bg-orange-2 transition"
+      >
+        重試
+      </button>
+    </div>
+  );
+}

--- a/src/components/home/HeroBanner.tsx
+++ b/src/components/home/HeroBanner.tsx
@@ -1,0 +1,23 @@
+import type { HomeData } from '../../types/home';
+
+interface Props {
+  season: HomeData['season'];
+  phase: HomeData['phase'];
+  currentWeek: HomeData['currentWeek'];
+}
+
+export function HeroBanner({ season, phase, currentWeek }: Props) {
+  return (
+    <header className="text-center mb-8">
+      <h1 className="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-2">
+        TAAN BASKETBALL
+      </h1>
+      <p className="font-display text-xl text-navy tracking-wide">
+        第 {season} 季
+      </p>
+      <p className="text-txt-mid text-sm mt-1">
+        {phase} · 第 {currentWeek} 週
+      </p>
+    </header>
+  );
+}

--- a/src/components/home/HomeDashboard.tsx
+++ b/src/components/home/HomeDashboard.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { HomeData } from '../../types/home';
+import { fetchData } from '../../lib/api';
+import { SkeletonState } from './SkeletonState';
+import { ErrorState } from './ErrorState';
+import { EmptyState } from './EmptyState';
+import { HeroBanner } from './HeroBanner';
+import { ScheduleBlock } from './ScheduleBlock';
+import { MiniStandings } from './MiniStandings';
+import { MiniLeaders } from './MiniLeaders';
+import { MiniDragon } from './MiniDragon';
+
+type Status = 'loading' | 'error' | 'empty' | 'ok';
+
+interface Props {
+  baseUrl: string;
+}
+
+export function HomeDashboard({ baseUrl }: Props) {
+  const [data, setData] = useState<HomeData | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+
+    (async () => {
+      const result = await fetchData<HomeData>('home');
+      if (cancelled) return;
+
+      if (result.source === 'error' || !result.data) {
+        setStatus('error');
+        return;
+      }
+
+      const home = result.data;
+      setData(home);
+
+      const hasData =
+        (home.standings?.length ?? 0) > 0 ||
+        (home.dragonTop10?.length ?? 0) > 0;
+
+      if (!hasData) {
+        setStatus('empty');
+        return;
+      }
+
+      setStatus('ok');
+    })();
+
+    return () => { cancelled = true; };
+  }, [reloadKey]);
+
+  const handleRetry = useCallback(() => setReloadKey((k) => k + 1), []);
+
+  if (status === 'loading') return <SkeletonState />;
+  if (status === 'error') return <ErrorState onRetry={handleRetry} />;
+  if (status === 'empty' || !data) return <EmptyState />;
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 md:px-8 pb-8" data-testid="home-dashboard">
+      <HeroBanner
+        season={data.season}
+        phase={data.phase}
+        currentWeek={data.currentWeek}
+      />
+
+      <ScheduleBlock scheduleInfo={data.scheduleInfo} baseUrl={baseUrl} />
+
+      <MiniLeaders miniStats={data.miniStats} baseUrl={baseUrl} />
+
+      {/* 戰績榜 + 龍虎榜：mobile 垂直堆疊、desktop 並排兩欄 */}
+      <div className="md:grid md:grid-cols-2 md:gap-4">
+        <MiniStandings teams={data.standings} baseUrl={baseUrl} />
+        <MiniDragon dragonTop10={data.dragonTop10} baseUrl={baseUrl} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/MiniDragon.tsx
+++ b/src/components/home/MiniDragon.tsx
@@ -1,0 +1,79 @@
+import type { DragonEntry } from '../../types/home';
+import { limitTop } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  dragonTop10: DragonEntry[];
+  baseUrl: string;
+}
+
+export function MiniDragon({ dragonTop10, baseUrl }: Props) {
+  const top5 = limitTop(dragonTop10, 5);
+  const href = `${baseUrl.replace(/\/$/, '')}/roster?tab=dragon`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-dragon"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">🐉 龍虎榜</h2>
+
+      {/* Mobile：compact rows */}
+      <div className="md:hidden space-y-2">
+        {top5.map((entry) => {
+          const color = TEAM_CONFIG[entry.team]?.color ?? '#999';
+          return (
+            <div
+              key={entry.rank}
+              data-testid="dragon-row"
+              className="flex items-center gap-2 border-b border-warm-1 last:border-0 py-1.5"
+            >
+              <span data-testid="rank" className="text-xs text-txt-mid w-4">{entry.rank}</span>
+              <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: color }} />
+              <span data-testid="name" className="font-bold text-sm text-navy flex-1">{entry.name}</span>
+              <span data-testid="team" className="text-xs text-txt-mid">{entry.team}</span>
+              <span data-testid="total" className="text-sm font-condensed text-orange">{entry.total}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Desktop：table */}
+      <div className="hidden md:block">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-txt-mid border-b border-warm-2">
+              <th className="text-left py-1 w-6">#</th>
+              <th className="text-left py-1">名</th>
+              <th className="text-left py-1">隊</th>
+              <th className="text-right py-1">總分</th>
+            </tr>
+          </thead>
+          <tbody>
+            {top5.map((entry) => {
+              const color = TEAM_CONFIG[entry.team]?.color ?? '#999';
+              return (
+                <tr key={entry.rank} data-testid="dragon-row" className="border-b border-warm-1 last:border-0">
+                  <td className="py-1.5"><span data-testid="rank" className="text-txt-mid">{entry.rank}</span></td>
+                  <td className="py-1.5">
+                    <div className="flex items-center gap-1.5">
+                      <span className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
+                      <span data-testid="name" className="font-bold text-navy">{entry.name}</span>
+                    </div>
+                  </td>
+                  <td className="py-1.5"><span data-testid="team">{entry.team}</span></td>
+                  <td className="py-1.5 text-right"><span data-testid="total" className="text-orange font-condensed">{entry.total}</span></td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 text-right">
+        <a href={href} className="text-sm font-bold text-orange hover:underline">
+          看完整龍虎榜 →
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/MiniLeaders.tsx
+++ b/src/components/home/MiniLeaders.tsx
@@ -1,0 +1,59 @@
+import type { MiniStatCategory } from '../../types/home';
+import { limitTop } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  miniStats: { pts: MiniStatCategory; reb: MiniStatCategory; ast: MiniStatCategory };
+  baseUrl: string;
+}
+
+function StatCategory({ cat }: { cat: MiniStatCategory }) {
+  const top3 = limitTop(cat.players, 3);
+  return (
+    <div className="flex-1 min-w-0" data-testid="leader-category">
+      <h3 className="text-xs font-bold text-txt-mid mb-2 uppercase tracking-wide">
+        {cat.label} {cat.unit}
+      </h3>
+      <div className="space-y-1">
+        {top3.map((player) => {
+          const color = TEAM_CONFIG[player.team]?.color ?? '#999';
+          return (
+            <div
+              key={`${player.name}-${player.rank}`}
+              className="flex items-center gap-1.5"
+              data-testid="leader-entry"
+            >
+              <span className="text-xs text-txt-mid w-4">{player.rank}</span>
+              <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+              <span data-testid="leader-name" className="text-sm font-bold text-navy truncate flex-1">{player.name}</span>
+              <span className="text-sm text-orange font-condensed shrink-0">{player.val}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function MiniLeaders({ miniStats, baseUrl }: Props) {
+  const href = `${baseUrl.replace(/\/$/, '')}/boxscore?tab=leaders`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-leaders"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">📊 領先榜</h2>
+      {/* 三指標橫排（md 以上），直排（mobile） */}
+      <div className="flex flex-col md:flex-row gap-4">
+        <StatCategory cat={miniStats.pts} />
+        <StatCategory cat={miniStats.reb} />
+        <StatCategory cat={miniStats.ast} />
+      </div>
+      <div className="mt-3 text-right">
+        <a href={href} className="text-sm font-bold text-orange hover:underline">
+          看完整領先榜 →
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/MiniStandings.tsx
+++ b/src/components/home/MiniStandings.tsx
@@ -1,0 +1,113 @@
+import type { HomeStandingTeam } from '../../types/home';
+import { getStreakStyle } from '../../lib/home-utils';
+import { TEAM_CONFIG } from '../../config/teams';
+
+interface Props {
+  teams: HomeStandingTeam[];
+  baseUrl: string;
+}
+
+function teamDotStyle(teamId: string) {
+  const config = TEAM_CONFIG[teamId];
+  return { backgroundColor: config?.color ?? '#999' };
+}
+
+function buildRosterHref(baseUrl: string, teamId: string) {
+  const config = TEAM_CONFIG[teamId];
+  return `${baseUrl.replace(/\/$/, '')}/roster?team=${config?.id ?? teamId}`;
+}
+
+function StreakCell({ team }: { team: HomeStandingTeam }) {
+  const { colorClass, arrow } = getStreakStyle(team.streakType);
+  return (
+    <span
+      data-testid="streak"
+      data-streak-type={team.streakType ?? ''}
+      className={`font-condensed text-sm ${colorClass}`}
+    >
+      {team.streak}
+      {arrow ? <span data-testid="streak-icon" aria-hidden="true"> {arrow}</span> : null}
+    </span>
+  );
+}
+
+export function MiniStandings({ teams, baseUrl }: Props) {
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-standings"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-3">🏆 戰績榜</h2>
+
+      {/* Mobile：compact rows（整列可點） */}
+      <div className="md:hidden space-y-2">
+        {teams.map((team) => (
+          <a
+            key={team.team}
+            href={buildRosterHref(baseUrl, team.team)}
+            data-testid="home-standings-row"
+            className="flex items-center justify-between py-1.5 border-b border-warm-1 last:border-0 hover:bg-warm-1 rounded px-1 transition"
+            aria-label={`${team.name} 第 ${team.rank} 名`}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span data-testid="rank" className="text-xs text-txt-mid w-4 shrink-0">{team.rank}</span>
+              <span data-testid="team-dot" className="w-2.5 h-2.5 rounded-full shrink-0" style={teamDotStyle(team.team)} />
+              <span data-testid="team-name" className="font-bold text-sm text-navy truncate">{team.name}</span>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <span data-testid="record" className="text-xs text-txt-mid">{team.record}</span>
+              <StreakCell team={team} />
+            </div>
+          </a>
+        ))}
+      </div>
+
+      {/* Desktop：table */}
+      <div className="hidden md:block">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs text-txt-mid border-b border-warm-2">
+              <th className="text-left py-1 w-6">#</th>
+              <th className="text-left py-1">隊伍</th>
+              <th className="text-left py-1">勝敗</th>
+              <th className="text-left py-1">勝率</th>
+              <th className="text-left py-1">連勝</th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team) => (
+              <tr
+                key={team.team}
+                data-testid="home-standings-row"
+                className="border-b border-warm-1 last:border-0 hover:bg-warm-1 transition"
+              >
+                <td className="py-1.5"><span data-testid="rank" className="text-txt-mid">{team.rank}</span></td>
+                <td className="py-1.5">
+                  <a
+                    href={buildRosterHref(baseUrl, team.team)}
+                    className="flex items-center gap-1.5 hover:text-orange"
+                  >
+                    <span data-testid="team-dot" className="w-2.5 h-2.5 rounded-full" style={teamDotStyle(team.team)} />
+                    <span data-testid="team-name" className="font-bold text-navy">{team.name}</span>
+                  </a>
+                </td>
+                <td className="py-1.5"><span data-testid="record">{team.record}</span></td>
+                <td className="py-1.5"><span data-testid="pct">{team.pct}</span></td>
+                <td className="py-1.5"><StreakCell team={team} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 text-right">
+        <a
+          href={`${baseUrl.replace(/\/$/, '')}/standings`}
+          className="text-sm font-bold text-orange hover:underline"
+        >
+          看完整戰績 →
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/ScheduleBlock.tsx
+++ b/src/components/home/ScheduleBlock.tsx
@@ -1,0 +1,28 @@
+import type { HomeData } from '../../types/home';
+
+interface Props {
+  scheduleInfo: HomeData['scheduleInfo'];
+  baseUrl: string;
+}
+
+export function ScheduleBlock({ scheduleInfo, baseUrl }: Props) {
+  const href = `${baseUrl.replace(/\/$/, '')}/schedule`;
+  return (
+    <section
+      className="bg-white border border-warm-2 rounded-2xl p-5 mb-4"
+      data-testid="home-schedule"
+    >
+      <h2 className="font-condensed font-bold text-navy text-lg mb-2">📅 本週賽程</h2>
+      <p className="text-txt-dark mb-1">
+        下次比賽：{scheduleInfo.date}
+      </p>
+      <p className="text-txt-mid text-sm mb-3">📍 {scheduleInfo.venue}</p>
+      <a
+        href={href}
+        className="inline-block text-sm font-bold text-orange hover:underline"
+      >
+        看本週對戰 →
+      </a>
+    </section>
+  );
+}

--- a/src/components/home/SkeletonState.tsx
+++ b/src/components/home/SkeletonState.tsx
@@ -1,0 +1,15 @@
+export function SkeletonState() {
+  return (
+    <div className="px-4 md:px-8 py-6 max-w-6xl mx-auto animate-pulse" data-testid="home-skeleton">
+      {/* Hero */}
+      <div className="text-center mb-8">
+        <div className="h-10 w-48 bg-gray-200 rounded mx-auto mb-2" />
+        <div className="h-5 w-32 bg-gray-200 rounded mx-auto" />
+      </div>
+      {/* 4 區塊 */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-32 bg-gray-200 rounded-2xl mb-4" />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/home-utils.ts
+++ b/src/lib/home-utils.ts
@@ -1,0 +1,17 @@
+import type { HomeStreakType } from '../types/home';
+
+export interface StreakStyle {
+  colorClass: string;
+  arrow: '' | '↑' | '↓';
+}
+
+export function getStreakStyle(type: HomeStreakType): StreakStyle {
+  if (type === 'win') return { colorClass: 'text-orange', arrow: '↑' };
+  if (type === 'lose') return { colorClass: 'text-red-600', arrow: '↓' };
+  return { colorClass: 'text-txt-mid', arrow: '' };
+}
+
+/** slice 並在長度不足時安全回傳現有（不報錯，不補空白佔位） */
+export function limitTop<T>(arr: T[], n: number): T[] {
+  return arr.slice(0, n);
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,36 +1,10 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { NAV_ITEMS } from '../config/nav';
+import { HomeDashboard } from '../components/home/HomeDashboard';
 
-const ENABLED_PAGES = NAV_ITEMS.filter((item) => item.id !== 'home');
+const baseUrl = import.meta.env.BASE_URL;
 ---
 
 <Layout title="首頁" active="home">
-  <section class="px-4 md:px-8 py-8 md:py-12 max-w-6xl mx-auto">
-    <header class="text-center mb-10 md:mb-14">
-      <h1 class="font-hero text-4xl md:text-6xl text-orange tracking-wider mb-3">
-        TAAN BASKETBALL
-      </h1>
-      <p class="font-display text-xl md:text-2xl text-navy tracking-wide">
-        大安ㄍㄤㄍㄤ好籃球聯盟
-      </p>
-      <p class="text-txt-mid text-sm md:text-base mt-3">
-        賽程・戰績・球員・龍虎榜・即時統計
-      </p>
-    </header>
-
-    <nav aria-label="頁面導覽" class="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
-      {ENABLED_PAGES.map((item) => (
-        <a
-          href={`${import.meta.env.BASE_URL.replace(/\/$/, '')}${item.href}`}
-          class="bg-white border border-warm-2 rounded-2xl p-5 md:p-6 flex flex-col items-center gap-2 transition-all hover:border-orange hover:shadow-lg hover:-translate-y-0.5"
-        >
-          <span class="text-3xl md:text-4xl" aria-hidden="true">{item.icon}</span>
-          <span class="font-condensed font-bold text-base md:text-lg text-navy tracking-wide">
-            {item.label}
-          </span>
-        </a>
-      ))}
-    </nav>
-  </section>
+  <HomeDashboard client:visible baseUrl={baseUrl} />
 </Layout>

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -1,0 +1,51 @@
+export type HomeStreakType = 'win' | 'lose' | null;
+
+export interface MiniStatsPlayer {
+  rank: number;
+  name: string;
+  team: string;
+  val: number;
+}
+
+export interface MiniStatCategory {
+  label: string;
+  unit: string;
+  players: MiniStatsPlayer[];
+}
+
+export interface HomeStandingTeam {
+  rank: number;
+  name: string;
+  team: string;
+  record: string;
+  pct: string;
+  history: string[];
+  streak: string;
+  streakType: HomeStreakType;
+}
+
+export interface DragonEntry {
+  rank: number;
+  name: string;
+  team: string;
+  att: number;
+  duty: number;
+  total: number;
+}
+
+export interface HomeData {
+  season: number;
+  currentWeek: number;
+  phase: string;
+  scheduleInfo: {
+    date: string;
+    venue: string;
+  };
+  standings: HomeStandingTeam[];
+  dragonTop10: DragonEntry[];
+  miniStats: {
+    pts: MiniStatCategory;
+    reb: MiniStatCategory;
+    ast: MiniStatCategory;
+  };
+}

--- a/tests/e2e/features/home/home-hero-schedule.spec.ts
+++ b/tests/e2e/features/home/home-hero-schedule.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * /（首頁）E2E — Hero + 本週賽程區塊
+ *
+ * Coverage: AC-1, AC-2, AC-8（CTA /schedule）
+ *
+ * 測試資料策略：
+ * - 攔截 GAS + /data/home.json，使用 mockHomeData() 正常快照
+ * - 不打 production GAS
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockHomeAPI } from '../../../helpers/mock-api';
+import { mockHomeData } from '../../../fixtures/home';
+
+test.describe('Home — Hero + 本週賽程 @home', () => {
+  // ── AC-1 ──
+  test('AC-1: Hero 顯示「TAAN BASKETBALL」+ 第 25 季 + 例行賽 + 第 3 週', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // UI 結構
+    await expect(page.getByRole('heading', { name: /TAAN BASKETBALL/i })).toBeVisible();
+    await expect(page.getByText(/第\s*25\s*季/)).toBeVisible();
+    await expect(page.getByText(/例行賽/)).toBeVisible();
+    await expect(page.getByText(/第\s*3\s*週/)).toBeVisible();
+  });
+
+  // ── AC-2 ──
+  test('AC-2: 本週賽程區塊顯示日期 + 場地', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // UI 結構
+    const scheduleBlock = page.getByTestId('home-schedule');
+    await expect(scheduleBlock).toBeVisible();
+    await expect(scheduleBlock.getByText(/2026.*2.*14/)).toBeVisible();
+    await expect(scheduleBlock.getByText(/三重體育館/)).toBeVisible();
+  });
+
+  // ── AC-2 CTA + AC-8 ──
+  test('AC-2/8: 本週賽程 CTA 連到 /schedule', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // 互動流程
+    const cta = page.getByTestId('home-schedule').getByRole('link', { name: /看本週對戰/ });
+    await expect(cta).toBeVisible();
+
+    // API 驗證 — URL 指向 /schedule
+    const href = await cta.getAttribute('href');
+    expect(href).toMatch(/\/schedule/);
+  });
+});

--- a/tests/e2e/features/home/home-leaders-dragon.spec.ts
+++ b/tests/e2e/features/home/home-leaders-dragon.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * /（首頁）E2E — 領先榜 + 龍虎榜區塊
+ *
+ * Coverage: AC-5, AC-6, AC-7, AC-8（CTA）
+ *
+ * 測試資料策略：
+ * - 攔截 GAS + /data/home.json，使用 mockHomeData()
+ * - 不打 production GAS
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockHomeAPI } from '../../../helpers/mock-api';
+import { mockHomeData } from '../../../fixtures/home';
+
+test.describe('Home — 領先榜 + 龍虎榜 @home @leaders @dragon', () => {
+  // ── AC-5 ──
+  test('AC-5: 領先榜三指標（得分/籃板/助攻）各顯示 top 3 並排', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const block = page.getByTestId('home-leaders');
+    await expect(block).toBeVisible();
+
+    // 三個指標欄
+    const cats = block.getByTestId('leader-category');
+    await expect(cats).toHaveCount(3);
+
+    // 第一欄（得分）有 top 3 entries
+    const firstCat = cats.first();
+    await expect(firstCat.getByTestId('leader-entry')).toHaveCount(3);
+    await expect(firstCat.getByTestId('leader-entry').first().getByTestId('leader-name'))
+      .toContainText('黃偉訓');
+  });
+
+  // ── AC-6 + AC-8 ──
+  test('AC-6/8: 領先榜 CTA 連 /boxscore?tab=leaders', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const cta = page.getByTestId('home-leaders').getByRole('link', { name: /看完整領先榜/ });
+    await expect(cta).toBeVisible();
+
+    const href = await cta.getAttribute('href');
+    expect(href).toMatch(/\/boxscore\?tab=leaders/);
+  });
+
+  // ── AC-7 ──
+  test('AC-7: 龍虎榜顯示 top 5（rank / 名 / 隊 / 總分）', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const block = page.getByTestId('home-dragon');
+    await expect(block).toBeVisible();
+
+    const rows = block.getByTestId('dragon-row');
+    await expect(rows).toHaveCount(5);
+
+    // 確認第一列欄位
+    const first = rows.first();
+    await expect(first.getByTestId('rank')).toContainText('1');
+    await expect(first.getByTestId('name')).toContainText('韋承志');
+    await expect(first.getByTestId('team')).toContainText('紅');
+    await expect(first.getByTestId('total')).toContainText('16');
+  });
+
+  // ── AC-7 CTA + AC-8 ──
+  test('AC-7/8: 龍虎榜 CTA 連 /roster?tab=dragon', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const cta = page.getByTestId('home-dragon').getByRole('link', { name: /看完整龍虎榜/ });
+    await expect(cta).toBeVisible();
+
+    const href = await cta.getAttribute('href');
+    expect(href).toMatch(/\/roster\?tab=dragon/);
+  });
+});

--- a/tests/e2e/features/home/home-rwd.spec.ts
+++ b/tests/e2e/features/home/home-rwd.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * /（首頁）E2E — RWD 適配
+ *
+ * Coverage: AC-10, AC-11
+ *
+ * 測試資料策略：
+ * - 使用 mockHomeData() 正常快照
+ * - 手機情境由 features-mobile project（Pixel 7）自動執行，此檔也可指定 viewport
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockHomeAPI } from '../../../helpers/mock-api';
+import { mockHomeData } from '../../../fixtures/home';
+
+test.describe('Home — RWD @home @rwd', () => {
+  // ── AC-10 手機：垂直堆疊 ──
+  test('AC-10: 手機（< 768px）各區塊垂直堆疊', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const container = page.getByTestId('home-dashboard');
+    await expect(container).toBeVisible();
+
+    // 各區塊可見（不驗 CSS，驗功能性 - 區塊可見即可）
+    await expect(page.getByTestId('home-schedule')).toBeVisible();
+    await expect(page.getByTestId('home-standings')).toBeVisible();
+    await expect(page.getByTestId('home-leaders')).toBeVisible();
+    await expect(page.getByTestId('home-dragon')).toBeVisible();
+
+    // 戰績榜 + 龍虎榜在手機上應為全寬（不並排）
+    const standingsBox = await page.getByTestId('home-standings').boundingBox();
+    const dragonBox = await page.getByTestId('home-dragon').boundingBox();
+    // 兩者 top 不同 → 垂直堆疊
+    expect(standingsBox!.y).not.toEqual(dragonBox!.y);
+  });
+
+  // ── AC-11 桌機：雙欄 + 橫排 ──
+  test('AC-11: 桌機（≥ 768px）戰績榜 + 龍虎榜並排兩欄', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const standingsBox = await page.getByTestId('home-standings').boundingBox();
+    const dragonBox = await page.getByTestId('home-dragon').boundingBox();
+
+    // 桌機：兩欄並排 → y 接近（同一 row）
+    expect(Math.abs(standingsBox!.y - dragonBox!.y)).toBeLessThan(50);
+  });
+
+  // ── AC-11 領先榜橫排 ──
+  test('AC-11: 桌機領先榜三指標橫排', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const cats = page.getByTestId('home-leaders').getByTestId('leader-category');
+    await expect(cats).toHaveCount(3);
+
+    const firstBox = await cats.nth(0).boundingBox();
+    const thirdBox = await cats.nth(2).boundingBox();
+
+    // 橫排：y 接近（同一 row），x 遞增
+    expect(Math.abs(firstBox!.y - thirdBox!.y)).toBeLessThan(50);
+    expect(thirdBox!.x).toBeGreaterThan(firstBox!.x);
+  });
+});

--- a/tests/e2e/features/home/home-standings.spec.ts
+++ b/tests/e2e/features/home/home-standings.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * /（首頁）E2E — 戰績榜迷你版區塊
+ *
+ * Coverage: AC-3, AC-4, AC-8（CTA /standings）, AC-9（隊伍列 deep link）
+ *
+ * 測試資料策略：
+ * - 攔截 GAS + /data/home.json，使用 mockHomeData()
+ * - 不打 production GAS
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockHomeAPI } from '../../../helpers/mock-api';
+import { mockHomeData } from '../../../fixtures/home';
+
+test.describe('Home — 戰績榜迷你版 @home @standings', () => {
+  // ── AC-3 ──
+  test('AC-3: 戰績榜顯示 6 隊（rank / 隊色點+名 / 勝敗 / 勝率 / 連勝紀錄）', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // UI 結構
+    const block = page.getByTestId('home-standings');
+    await expect(block).toBeVisible();
+
+    const rows = block.getByTestId('home-standings-row');
+    await expect(rows).toHaveCount(6);
+
+    // 確認第一列欄位
+    const first = rows.first();
+    await expect(first.getByTestId('rank')).toContainText('1');
+    await expect(first.getByTestId('team-dot')).toBeVisible();
+    await expect(first.getByTestId('team-name')).toContainText('綠');
+    await expect(first.getByTestId('record')).toContainText(/勝/);
+    await expect(first.getByTestId('pct')).toContainText('66.7');
+    await expect(first.getByTestId('streak')).toContainText(/連勝|連敗/);
+  });
+
+  // ── AC-3 CTA + AC-8 ──
+  test('AC-3/8: 戰績榜 CTA「看完整戰績」連 /standings', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    const cta = page.getByTestId('home-standings').getByRole('link', { name: /看完整戰績/ });
+    await expect(cta).toBeVisible();
+
+    const href = await cta.getAttribute('href');
+    expect(href).toMatch(/\/standings/);
+  });
+
+  // ── AC-4: 連勝視覺 ──
+  test('AC-4: 連勝隊伍 streak 橙字 + ↑ icon', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // 綠隊（rank 1）是 win
+    const greenRow = page
+      .getByTestId('home-standings')
+      .getByTestId('home-standings-row')
+      .filter({ has: page.getByTestId('team-name').filter({ hasText: '綠' }) });
+
+    const streak = greenRow.getByTestId('streak');
+    await expect(streak).toHaveAttribute('data-streak-type', 'win');
+    await expect(streak).toContainText('↑');
+  });
+
+  // ── AC-4: 連敗視覺 ──
+  test('AC-4: 連敗隊伍 streak 紅字 + ↓ icon', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // 紅隊（rank 2）是 lose
+    const redRow = page
+      .getByTestId('home-standings')
+      .getByTestId('home-standings-row')
+      .filter({ has: page.getByTestId('team-name').filter({ hasText: '紅' }) });
+
+    const streak = redRow.getByTestId('streak');
+    await expect(streak).toHaveAttribute('data-streak-type', 'lose');
+    await expect(streak).toContainText('↓');
+  });
+
+  // ── AC-9: 隊伍列 deep link ──
+  test('AC-9: 點戰績榜隊伍列跳 /roster?team=<id>', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData());
+    await page.goto('/');
+
+    // 互動流程：點第一列
+    const firstRow = page
+      .getByTestId('home-standings')
+      .getByTestId('home-standings-row')
+      .first();
+    const href = await firstRow.evaluate((el) => {
+      const a = el.querySelector('a') ?? el.closest('a');
+      return a?.getAttribute('href') ?? '';
+    });
+
+    // API 驗證 — URL 含 /roster?team=
+    expect(href).toMatch(/\/roster\?team=/);
+  });
+});

--- a/tests/e2e/features/home/home-states.spec.ts
+++ b/tests/e2e/features/home/home-states.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * /（首頁）E2E — 三狀態 + 邊界/異常
+ *
+ * Coverage: AC-12, AC-13, AC-14, AC-15, AC-16, AC-17
+ * qa-v2 補充：AC-13 重試按鈕行為（B-19）
+ *
+ * 測試資料策略：
+ * - 延遲模擬 skeleton；allFail 模擬全失敗；空資料模擬賽季未開始
+ * - 邊界情境使用 mock*WithFew* 工廠
+ */
+
+import { test, expect } from '@playwright/test';
+import { mockHomeAPI } from '../../../helpers/mock-api';
+import {
+  mockHomeData,
+  mockEmptyHomeData,
+  mockHomeDataWithNullStreak,
+  mockHomeDataWithFewPlayers,
+  mockHomeDataWithFewDragon,
+} from '../../../fixtures/home';
+
+test.describe('Home — 三狀態 + 邊界 @home @states', () => {
+  // ── AC-12 ──
+  test('AC-12: 資料載入中顯示 skeleton', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeData(), { delayMs: 2000 });
+    await page.goto('/');
+
+    // 未 await 資料完成前，skeleton 應可見
+    await expect(page.getByTestId('home-skeleton')).toBeVisible({ timeout: 1000 });
+    // 資料到位後 skeleton 消失
+    await expect(page.getByTestId('home-skeleton')).not.toBeVisible({ timeout: 5000 });
+  });
+
+  // ── AC-13 ──
+  test('AC-13: GAS + JSON 全失敗 → 顯示錯誤訊息 + 重試按鈕', async ({ page }) => {
+    await mockHomeAPI(page, null, { allFail: true });
+    await page.goto('/');
+
+    // UI 結構
+    await expect(page.getByTestId('home-error')).toBeVisible();
+    await expect(page.getByText(/無法載入聯盟資訊/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /重試/ })).toBeVisible();
+  });
+
+  // ── AC-13 重試 [qa-v2 補充] ──
+  test('AC-13 [qa-v2 補充]: 點重試按鈕後重新 fetch', async ({ page }) => {
+    let fetchCount = 0;
+    // 第一次失敗，第二次成功
+    await page.route(/\/data\/home\.json$/, async (route) => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        await route.fulfill({ status: 500, body: 'fail' });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockHomeData()),
+        });
+      }
+    });
+    await page.goto('/');
+
+    // 等待錯誤狀態
+    await expect(page.getByTestId('home-error')).toBeVisible();
+
+    // 互動流程：點重試
+    await page.getByRole('button', { name: /重試/ }).click();
+
+    // 重試後 error 消失，資料出現
+    await expect(page.getByTestId('home-error')).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('home-standings')).toBeVisible();
+  });
+
+  // ── AC-14 ──
+  test('AC-14: home.json 空資料 → 「賽季尚未開始」訊息', async ({ page }) => {
+    await mockHomeAPI(page, mockEmptyHomeData());
+    await page.goto('/');
+
+    await expect(page.getByTestId('home-empty')).toBeVisible();
+    await expect(page.getByText(/賽季尚未開始/)).toBeVisible();
+  });
+
+  // ── AC-15 ──
+  test('AC-15: streakType null → 不顯示 icon，只顯示文字', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeDataWithNullStreak());
+    await page.goto('/');
+
+    const rows = page.getByTestId('home-standings').getByTestId('home-standings-row');
+    const first = rows.first();
+
+    // streak icon 不可見
+    await expect(first.getByTestId('streak-icon')).not.toBeVisible();
+    // streak 文字本身仍顯示
+    await expect(first.getByTestId('streak')).toBeVisible();
+  });
+
+  // ── AC-16 ──
+  test('AC-16: 領先榜某指標 players < 3 → 顯示有的，不報錯', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeDataWithFewPlayers());
+    await page.goto('/');
+
+    await expect(page.getByTestId('home-error')).not.toBeVisible();
+
+    // 第一欄（得分）只有 1 筆
+    const ptsCat = page.getByTestId('home-leaders')
+      .getByTestId('leader-category').first();
+    await expect(ptsCat.getByTestId('leader-entry')).toHaveCount(1);
+
+    // 第二欄（籃板）只有 2 筆
+    const rebCat = page.getByTestId('home-leaders')
+      .getByTestId('leader-category').nth(1);
+    await expect(rebCat.getByTestId('leader-entry')).toHaveCount(2);
+  });
+
+  // ── AC-17 ──
+  test('AC-17: 龍虎榜 < 5 筆 → 顯示有的，不報錯', async ({ page }) => {
+    await mockHomeAPI(page, mockHomeDataWithFewDragon());
+    await page.goto('/');
+
+    await expect(page.getByTestId('home-error')).not.toBeVisible();
+    const rows = page.getByTestId('home-dragon').getByTestId('dragon-row');
+    await expect(rows).toHaveCount(2);
+  });
+});

--- a/tests/environments.yml
+++ b/tests/environments.yml
@@ -35,10 +35,10 @@ env_vars:
       acc_pw_section: taan-basketball-league
       ci: gh variable (vars)
     inject_at:
-      dev: .env.local
-      test: vitest.config.ts define（vi.stubEnv 替代）
+      dev: .env.local（可留空，api.ts 偵測 placeholder 後自動 fallback JSON）
+      test: vi.stubEnv('PUBLIC_GAS_WEBAPP_URL', ...) 於各 integration test beforeEach
       build: .github/workflows/*.yml build job env
-    required_for: [dev, build, deploy]
+    required_for: [build, deploy]
 
 # 測試覆蓋目標
 coverage:

--- a/tests/fixtures/home.ts
+++ b/tests/fixtures/home.ts
@@ -1,0 +1,163 @@
+/**
+ * Home fixture 工廠
+ *
+ * 提供測試專用的固定範例資料。
+ * 結構對應 public/data/home.json（GAS 整合來源）。
+ * 不會打 production Google Sheets，所有資料均在此手寫。
+ */
+
+export type StreakType = 'win' | 'lose' | null;
+
+export interface HomeStandingTeam {
+  rank: number;
+  name: string;
+  team: string;
+  record: string;
+  pct: string;
+  history: string[];
+  streak: string;
+  streakType: StreakType;
+}
+
+export interface MiniStatsPlayer {
+  rank: number;
+  name: string;
+  team: string;
+  val: number;
+}
+
+export interface MiniStatCategory {
+  label: string;
+  unit: string;
+  players: MiniStatsPlayer[];
+}
+
+export interface DragonEntry {
+  rank: number;
+  name: string;
+  team: string;
+  att: number;
+  duty: number;
+  total: number;
+}
+
+export interface HomeData {
+  season: number;
+  currentWeek: number;
+  phase: string;
+  scheduleInfo: {
+    date: string;
+    venue: string;
+  };
+  standings: HomeStandingTeam[];
+  dragonTop10: DragonEntry[];
+  miniStats: {
+    pts: MiniStatCategory;
+    reb: MiniStatCategory;
+    ast: MiniStatCategory;
+  };
+}
+
+/** 完整正常情境 home data（對應 public/data/home.json 快照） */
+export function mockHomeData(): HomeData {
+  return {
+    season: 25,
+    currentWeek: 3,
+    phase: '例行賽',
+    scheduleInfo: {
+      date: '2026 / 2 / 14（六）07:30',
+      venue: '三重體育館',
+    },
+    standings: [
+      { rank: 1, name: '綠隊', team: '綠', record: '4勝 2敗', pct: '66.7%', history: ['L','W','W','L','W','W'], streak: '2連勝', streakType: 'win' },
+      { rank: 2, name: '紅隊', team: '紅', record: '4勝 2敗', pct: '66.7%', history: ['W','L','W','W','W','L'], streak: '1連敗', streakType: 'lose' },
+      { rank: 3, name: '黑隊', team: '黑', record: '3勝 3敗', pct: '50.0%', history: ['L','W','L','W','W','W'], streak: '2連勝', streakType: 'win' },
+      { rank: 4, name: '黃隊', team: '黃', record: '3勝 3敗', pct: '50.0%', history: ['W','W','L','L','L','W'], streak: '1連勝', streakType: 'win' },
+      { rank: 5, name: '白隊', team: '白', record: '3勝 3敗', pct: '50.0%', history: ['L','W','W','W','L','L'], streak: '2連敗', streakType: 'lose' },
+      { rank: 6, name: '藍隊', team: '藍', record: '1勝 5敗', pct: '16.7%', history: ['L','L','W','L','L','L'], streak: '3連敗', streakType: 'lose' },
+    ],
+    dragonTop10: [
+      { rank: 1,  name: '韋承志', team: '紅', att: 8, duty: 8, total: 16 },
+      { rank: 2,  name: '吳家豪', team: '綠', att: 6, duty: 6, total: 12 },
+      { rank: 3,  name: '李昊明', team: '黑', att: 8, duty: 3, total: 11 },
+      { rank: 4,  name: '趙尹旋', team: '紅', att: 7, duty: 3, total: 10 },
+      { rank: 5,  name: '李政軒', team: '黑', att: 8, duty: 1, total: 9 },
+      { rank: 6,  name: '楊承達', team: '黑', att: 5, duty: 3, total: 8 },
+      { rank: 7,  name: '陳鈞銘', team: '黃', att: 5, duty: 2, total: 7 },
+      { rank: 8,  name: '吳軒宇', team: '紅', att: 4, duty: 2, total: 6 },
+      { rank: 9,  name: '林志柏', team: '黑', att: 4, duty: 2, total: 6 },
+      { rank: 10, name: '江錒哲', team: '黃', att: 4, duty: 1, total: 5 },
+    ],
+    miniStats: {
+      pts: {
+        label: '得分', unit: 'PPG',
+        players: [
+          { rank: 1, name: '黃偉訓', team: '綠', val: 9.55 },
+          { rank: 2, name: '吳軒宇', team: '紅', val: 7.62 },
+          { rank: 3, name: '吳家豪', team: '綠', val: 7.00 },
+          { rank: 4, name: '陳彥汗', team: '白', val: 6.68 },
+        ],
+      },
+      reb: {
+        label: '籃板', unit: 'RPG',
+        players: [
+          { rank: 1, name: '陳曉川', team: '白', val: 4.90 },
+          { rank: 2, name: '江浩仲', team: '藍', val: 4.84 },
+          { rank: 3, name: '林毅豐', team: '黑', val: 4.08 },
+          { rank: 4, name: '李政軒', team: '黑', val: 4.04 },
+        ],
+      },
+      ast: {
+        label: '助攻', unit: 'APG',
+        players: [
+          { rank: 1, name: '梁修綸', team: '黑', val: 1.61 },
+          { rank: 2, name: '陳彥廷', team: '黃', val: 1.15 },
+          { rank: 3, name: '吳家豪', team: '綠', val: 1.11 },
+          { rank: 4, name: '連育樟', team: '綠', val: 1.09 },
+        ],
+      },
+    },
+  };
+}
+
+/** 空資料（賽季尚未開始） */
+export function mockEmptyHomeData(): HomeData {
+  return {
+    season: 0,
+    currentWeek: 0,
+    phase: '',
+    scheduleInfo: { date: '', venue: '' },
+    standings: [],
+    dragonTop10: [],
+    miniStats: {
+      pts: { label: '得分', unit: 'PPG', players: [] },
+      reb: { label: '籃板', unit: 'RPG', players: [] },
+      ast: { label: '助攻', unit: 'APG', players: [] },
+    },
+  };
+}
+
+/** streakType null 邊界情境 */
+export function mockHomeDataWithNullStreak(): HomeData {
+  const data = mockHomeData();
+  data.standings = data.standings.map((t) => ({ ...t, streakType: null as unknown as StreakType }));
+  return data;
+}
+
+/** 領先榜 players < 3 情境 */
+export function mockHomeDataWithFewPlayers(): HomeData {
+  const data = mockHomeData();
+  data.miniStats.pts.players = [{ rank: 1, name: '唯一得分王', team: '綠', val: 9.55 }];
+  data.miniStats.reb.players = [
+    { rank: 1, name: '籃板王甲', team: '白', val: 4.90 },
+    { rank: 2, name: '籃板王乙', team: '藍', val: 4.84 },
+  ];
+  return data;
+}
+
+/** 龍虎榜 < 5 情境 */
+export function mockHomeDataWithFewDragon(): HomeData {
+  const data = mockHomeData();
+  data.dragonTop10 = data.dragonTop10.slice(0, 2);
+  return data;
+}

--- a/tests/helpers/mock-api/home.ts
+++ b/tests/helpers/mock-api/home.ts
@@ -1,0 +1,24 @@
+/**
+ * Playwright Mock — Home（首頁 dashboard）攔截
+ *
+ * 涵蓋範圍：
+ *   - mockHomeAPI：攔截 GAS endpoint + /data/home.json
+ *
+ * 使用方式：
+ *   await mockHomeAPI(page, mockHomeData());
+ *   await mockHomeAPI(page, null, { gasFails: true });
+ *   await mockHomeAPI(page, null, { allFail: true });
+ *   await mockHomeAPI(page, mockHomeData(), { delayMs: 2000 });
+ */
+
+import type { Page } from '@playwright/test';
+import type { HomeData } from '../../fixtures/home';
+import { mockKindAPI, type MockOptions } from './schedule';
+
+export async function mockHomeAPI(
+  page: Page,
+  data: HomeData | null,
+  opts: MockOptions<HomeData> = {},
+): Promise<void> {
+  return mockKindAPI<HomeData>(page, /\/data\/home\.json$/, data, opts);
+}

--- a/tests/helpers/mock-api/index.ts
+++ b/tests/helpers/mock-api/index.ts
@@ -2,7 +2,8 @@
  * tests/helpers/mock-api — Re-export 統一入口
  *
  * 涵蓋範圍：
- *   集合 schedule / standings / boxscore / leaders / roster 五個 mock 模組，
+<<<<<<< HEAD
+ *   集合 schedule / standings / boxscore / leaders / roster / home 六個 mock 模組，
  *   供所有 E2E spec 以不變的 import path 使用：
  *   `import { ... } from '../../helpers/mock-api'`
  *
@@ -12,6 +13,7 @@
  *   boxscore.ts  — mockBoxscoreSheetsAPI + mockBoxscoreAndLeaders
  *   leaders.ts   — mockLeadersAPI
  *   roster.ts    — mockRosterAPI + mockDragonAPI + mockRosterAndDragon
+ *   home.ts      — mockHomeAPI（首頁 dashboard）
  */
 
 export { mockScheduleAPI, mockKindAPI } from './schedule';
@@ -27,6 +29,8 @@ export type { LeadersMockOptions } from './leaders';
 
 export { mockRosterAPI, mockDragonAPI, mockRosterAndDragon } from './roster';
 export type { RosterAndDragonMockOptions } from './roster';
+
+export { mockHomeAPI } from './home';
 
 // re-export types for fixture consumers
 export type { BoxscoreData, LeaderData } from './boxscore';

--- a/tests/unit/home-utils.test.ts
+++ b/tests/unit/home-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { getStreakStyle, limitTop } from '../../src/lib/home-utils';
+
+describe('getStreakStyle', () => {
+  it('win → 橙色 class + ↑ arrow', () => {
+    const result = getStreakStyle('win');
+    expect(result.arrow).toBe('↑');
+    expect(result.colorClass).toContain('orange');
+  });
+
+  it('lose → 紅色 class + ↓ arrow', () => {
+    const result = getStreakStyle('lose');
+    expect(result.arrow).toBe('↓');
+    expect(result.colorClass).toContain('red');
+  });
+
+  it('null → arrow 為空字串（不顯示 icon）', () => {
+    const result = getStreakStyle(null);
+    expect(result.arrow).toBe('');
+  });
+
+  it('null → colorClass 不含 orange 也不含 red', () => {
+    const result = getStreakStyle(null);
+    expect(result.colorClass).not.toContain('orange');
+    expect(result.colorClass).not.toContain('red');
+  });
+});
+
+describe('limitTop', () => {
+  it('超過指定數量時 slice', () => {
+    expect(limitTop([1, 2, 3, 4, 5], 3)).toEqual([1, 2, 3]);
+  });
+
+  it('剛好 n 筆不截斷', () => {
+    expect(limitTop([1, 2, 3], 3)).toEqual([1, 2, 3]);
+  });
+
+  it('少於 n 筆時回傳現有，不報錯', () => {
+    expect(limitTop([1], 3)).toEqual([1]);
+  });
+
+  it('空陣列回傳空陣列，不報錯', () => {
+    expect(limitTop([], 5)).toEqual([]);
+  });
+
+  it('支援 object 型別', () => {
+    const items = [{ name: 'A' }, { name: 'B' }];
+    expect(limitTop(items, 5)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

將首頁（`/`）從純導覽 grid 升級為 5 區塊即時概覽 dashboard，資料來源 `home.json`。

## Changes

- `src/types/home.ts` — HomeData TypeScript 型別定義
- `src/lib/home-utils.ts` — getStreakStyle、limitTop 工具函式
- `src/components/home/` — HomeDashboard island + 8 個子元件（Hero / Schedule / MiniStandings / MiniLeaders / MiniDragon / Skeleton / Error / Empty）
- `src/pages/index.astro` — 整合 HomeDashboard（移除舊 nav grid）
- `tests/fixtures/home.ts` — HomeData 測試工廠（含邊界情境）
- `tests/helpers/mock-api/home.ts` + index.ts — mockHomeAPI
- `tests/e2e/features/home/` — 5 個 E2E spec（22 cases，AC-1~17 完整覆蓋）
- `tests/unit/home-utils.test.ts` — 9 個 unit tests（U-1~U-4）
- `tests/environments.yml` — 補 env_vars.PUBLIC_GAS_WEBAPP_URL

## Test

- Unit + Integration：✅ 138/138 PASS
- E2E：Phase 6 驗收（UAT 部署後執行）
- Phase 3 test_gaps：T3 誤判 override（React 顯示元件，E2E 涵蓋，code-graph 不識別 Playwright spec）